### PR TITLE
refactor: remove redundant AsyncHandler and AsyncContextHandler types

### DIFF
--- a/event_bus.go
+++ b/event_bus.go
@@ -11,14 +11,8 @@ import (
 // Handler is a generic event handler function
 type Handler[T any] func(T)
 
-// AsyncHandler is a generic async event handler function
-type AsyncHandler[T any] func(T)
-
 // ContextHandler is a generic event handler function that accepts context
 type ContextHandler[T any] func(context.Context, T)
-
-// AsyncContextHandler is a generic async event handler function that accepts context
-type AsyncContextHandler[T any] func(context.Context, T)
 
 // SubscribeOption configures a subscription
 type SubscribeOption func(*internalHandler)


### PR DESCRIPTION
## Summary
- Removed `AsyncHandler[T]` and `AsyncContextHandler[T]` type definitions
- These types were identical to `Handler[T]` and `ContextHandler[T]` respectively
- Simplifies the API and reduces confusion

## Problem
The codebase had four handler types:
- `Handler[T any] func(T)`
- `AsyncHandler[T any] func(T)` (identical to Handler)
- `ContextHandler[T any] func(context.Context, T)`
- `AsyncContextHandler[T any] func(context.Context, T)` (identical to ContextHandler)

This was confusing because:
1. The "Async" types were functionally identical to their non-async counterparts
2. Async behavior is actually controlled by the `Async()` option, not the handler type
3. These redundant types were never actually used anywhere in the codebase

## Solution
Removed the redundant types, leaving only:
- `Handler[T any] func(T)` - for handlers without context
- `ContextHandler[T any] func(context.Context, T)` - for handlers with context

Both types can be made async using the `Async()` subscription option.

## Impact
- ✅ No breaking changes (types were never used)
- ✅ All tests pass
- ✅ Simpler, clearer API
- ✅ Less confusion for users

## Testing
- All existing tests pass without modification
- No functionality changes
- Verified with `-race` flag

🤖 Generated with [Claude Code](https://claude.ai/code)