### PR TITLE
style: apply gofmt formatting and add PR checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# Claude Code Instructions
+
+## Before Creating Pull Requests
+
+Before creating any pull request, you MUST:
+
+1. Run `go fmt ./...` to format all Go code
+2. Run tests with `go test ./...` to ensure all tests pass
+3. Check test coverage with `go test -coverprofile=coverage.out ./... && go tool cover -func=coverage.out`
+
+## Code Quality Standards
+
+- Maintain 100% test coverage for core functionality
+- Follow Go idioms and best practices
+- Use the options pattern for configuration where appropriate
+- Keep implementations simple and focused

--- a/event_bus.go
+++ b/event_bus.go
@@ -44,7 +44,7 @@ type EventBus struct {
 	afterPublish  PublishHook
 	mu            sync.RWMutex
 	wg            sync.WaitGroup
-	
+
 	// Optional persistence fields (nil if not using persistence)
 	store         EventStore
 	storePosition int64
@@ -59,12 +59,12 @@ func New(opts ...BusOption) *EventBus {
 	bus := &EventBus{
 		handlers: make(map[reflect.Type][]*internalHandler),
 	}
-	
+
 	// Apply all options
 	for _, opt := range opts {
 		opt(bus)
 	}
-	
+
 	return bus
 }
 


### PR DESCRIPTION
## Summary
- Apply `go fmt` to all Go files to ensure consistent formatting
- Add CLAUDE.md with PR checklist for future contributions

## Changes
- Formatted event_bus.go, persist.go, and persist_test.go with `go fmt`
- Created CLAUDE.md with instructions to run `go fmt ./...` before creating PRs

🤖 Generated with [Claude Code](https://claude.ai/code)