### PR TITLE
Remove unused Extensions API

### DIFF
--- a/event_bus.go
+++ b/event_bus.go
@@ -58,9 +58,6 @@ type EventBus struct {
 	store         EventStore
 	storePosition int64
 	storeMu       sync.RWMutex
-
-	// Extensions stored in sync.Map for thread-safety
-	extensions sync.Map
 }
 
 // EventType returns the fully qualified type name of an event.
@@ -345,16 +342,6 @@ func HandlerCount[T any](bus *EventBus) int {
 // Wait blocks until all async handlers complete
 func (bus *EventBus) Wait() {
 	bus.wg.Wait()
-}
-
-// SetExtension stores an extension
-func SetExtension(bus *EventBus, name string, extension any) {
-	bus.extensions.Store(name, extension)
-}
-
-// GetExtension retrieves an extension
-func GetExtension(bus *EventBus, name string) (any, bool) {
-	return bus.extensions.Load(name)
 }
 
 // callHandlerWithContext calls a handler with proper type checking and panic recovery

--- a/event_bus_test.go
+++ b/event_bus_test.go
@@ -2331,38 +2331,6 @@ func TestAsyncSequentialHandlerContextCancelled(t *testing.T) {
 	}
 }
 
-// TestExtensions tests the extensions functionality
-func TestExtensions(t *testing.T) {
-	bus := New()
-
-	// Test SetExtension and GetExtension functions
-	SetExtension(bus, "key1", "value1")
-	SetExtension(bus, "key2", 42)
-
-	val1, ok := GetExtension(bus, "key1")
-	if !ok || val1 != "value1" {
-		t.Errorf("expected 'value1', got %v", val1)
-	}
-
-	val2, ok := GetExtension(bus, "key2")
-	if !ok || val2 != 42 {
-		t.Errorf("expected 42, got %v", val2)
-	}
-
-	// Test non-existent key
-	_, ok = GetExtension(bus, "nonexistent")
-	if ok {
-		t.Error("expected false for non-existent key")
-	}
-
-	// Also test direct access to extensions
-	bus.extensions.Store("direct", "access")
-	val, ok := bus.extensions.Load("direct")
-	if !ok || val != "access" {
-		t.Errorf("expected 'access', got %v", val)
-	}
-}
-
 // TestWithBeforePublish tests the before publish hook
 func TestWithBeforePublish(t *testing.T) {
 	var hookCalled bool


### PR DESCRIPTION
## Summary
- Removes the Extensions API (`SetExtension`/`GetExtension`) that had unclear purpose and use cases
- Simplifies the EventBus structure by removing the `extensions sync.Map` field
- Improves code maintainability by reducing unnecessary API surface

## Changes
- ✅ Removed `extensions sync.Map` field from EventBus struct
- ✅ Removed `SetExtension()` and `GetExtension()` functions  
- ✅ Removed `TestExtensions()` test case
- ✅ Maintained 100% test coverage
- ✅ All tests pass with race detector enabled

## Test Plan
- [x] Run `go test ./...` - all tests pass
- [x] Run `go test -race ./...` - no race conditions detected
- [x] Run `go test -cover ./...` - 100% coverage maintained
- [x] Run `go fmt ./...` - code properly formatted
- [x] Run benchmarks - performance unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)