### PR TITLE
feat: add TypeNamer interface for explicit event type control

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,31 @@ bus.SetAfterPublishHook(func(eventType reflect.Type, event any) {
 })
 ```
 
+### Custom Event Type Names
+
+Control event type naming explicitly with the `TypeNamer` interface for stable names across refactoring:
+
+```go
+type UserCreatedEvent struct {
+    UserID string
+}
+
+// Implement TypeNamer for explicit type control
+func (e UserCreatedEvent) EventTypeName() string {
+    return "user.created.v1"
+}
+
+// Now EventType() returns "user.created.v1" instead of package-qualified name
+eventbus.Publish(bus, UserCreatedEvent{UserID: "123"})
+```
+
+Benefits:
+- **Stable event names** across package reorganization
+- **Version control** for event schema evolution
+- **External compatibility** with other event systems
+
+See [TypeNamer examples](docs/EXAMPLES.md#custom-event-type-names-typenamer) for versioning and migration patterns.
+
 ## Documentation
 
 - 📖 [**Complete Examples**](docs/EXAMPLES.md) - Comprehensive usage examples

--- a/persist.go
+++ b/persist.go
@@ -78,8 +78,8 @@ func (bus *EventBus) persistEvent(eventType reflect.Type, event any) {
 	bus.storeMu.Lock()
 	position := bus.storePosition + 1
 
-	// Use consistent type naming with EventType() function
-	typeName := eventType.String()
+	// Use EventType() to respect TypeNamer interface if implemented
+	typeName := EventType(event)
 
 	stored := &StoredEvent{
 		Position:  position,


### PR DESCRIPTION
## Summary

Adds the `TypeNamer` interface that allows events to provide their own type names, giving explicit control over event type naming.

## Motivation

The current `EventType()` function uses `reflect.TypeOf(event).String()`, which returns package-qualified names like `"github.com/myapp/events.UserCreated"`. This creates problems:

1. **Package refactoring breaks replays** - Moving events to different packages changes the type name
2. **No version control** - Can't implement event versioning schemes like "UserCreated.v1"
3. **External system incompatibility** - Can't match naming conventions of Kafka/other event stores

## Solution

Added `TypeNamer` interface with a single method:

```go
type TypeNamer interface {
    EventTypeName() string
}
```

Events can now implement this interface for explicit type control:

```go
type UserCreatedEvent struct {
    UserID string
}

func (e UserCreatedEvent) EventTypeName() string {
    return "user.created.v1"  // Stable across refactoring
}
```

## Changes

- Added `TypeNamer` interface to `event_bus.go`
- Updated `EventType()` to check for `TypeNamer` implementation
- Updated persistence layer to use `EventType()` (respects TypeNamer)
- Added 5 comprehensive test functions covering:
  - Publishing with TypeNamer
  - Persistence with TypeNamer
  - Replay with custom type names
  - Type name stability
  - Hook integration
- Updated documentation with examples for:
  - Basic TypeNamer usage
  - Event versioning patterns
  - Refactoring stability
  - External system compatibility

## Benefits

- **Stable event names** across package reorganization
- **Version control** for event schema evolution (v1, v2, etc.)
- **External compatibility** with other event systems
- **Backward compatible** - existing code continues to work with reflection-based names

## Test Coverage

100% test coverage maintained. All tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)