### PR TITLE
Add Store interface for event sourcing patterns

### DIFF
--- a/store.go
+++ b/store.go
@@ -1,0 +1,34 @@
+package eventbus
+
+import (
+	"context"
+	"time"
+)
+
+// Store defines the interface for event sourcing storage.
+// Unlike EventStore which is used for event bus persistence,
+// Store is designed for CQRS/ES patterns with streams and versions.
+type Store interface {
+	// Append appends events to a stream and returns the new version
+	Append(ctx context.Context, streamID string, events []Event) (int64, error)
+
+	// Read reads events from a stream starting from a version
+	Read(ctx context.Context, streamID string, fromVersion int64) ([]Event, error)
+
+	// ReadAll reads all events across all streams
+	ReadAll(ctx context.Context, fromEventID string, limit int) ([]Event, error)
+
+	// Close closes the store
+	Close() error
+}
+
+// Event represents an event in an event-sourced system
+type Event struct {
+	ID        string    `json:"id"`
+	StreamID  string    `json:"stream_id"`
+	Type      string    `json:"type"`
+	Data      []byte    `json:"data"`
+	Metadata  []byte    `json:"metadata,omitempty"`
+	Version   int64     `json:"version"`
+	Timestamp time.Time `json:"timestamp"`
+}


### PR DESCRIPTION
## Summary

Adds a new `Store` interface designed for CQRS/ES patterns with stream-based event storage.

## Changes

- New `Store` interface with stream-based operations
- `Event` struct with stream metadata and versioning
- Distinct from `EventStore` (event bus persistence) 

## Key Features

- **Stream organization**: Events grouped by stream ID with version control
- **ReadAll capability**: Support for event replay across all streams
- **Type safety**: Idiomatic Go interface for event sourcing implementations

## Use Cases

This interface enables:
- Building event-sourced aggregates and projections
- Remote storage implementations
- Stream-based event replay and catchup subscriptions

## Test Coverage

✅ Coverage remains at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)