### PR TITLE
feat: add state package implementing Durable Streams State Protocol

### DIFF
--- a/state/doc.go
+++ b/state/doc.go
@@ -1,0 +1,89 @@
+// Package state implements the Durable Streams State Protocol for ebu.
+//
+// The State Protocol provides database-style sync semantics on top of durable streams,
+// enabling insert, update, and delete operations on typed entities. This package is
+// optional and does not modify core ebu behavior.
+//
+// # Change Messages
+//
+// Change messages represent mutations to entities with a composite key (type + key):
+//
+//	// Insert a new user
+//	msg, _ := state.Insert("user:123", User{Name: "Alice"})
+//
+//	// Update a user
+//	msg, _ := state.Update("user:123", User{Name: "Alice Smith"})
+//
+//	// Update with old value for conflict detection
+//	msg, _ := state.UpdateWithOldValue("user:123", newUser, oldUser)
+//
+//	// Delete a user
+//	msg, _ := state.Delete[User]("user:123")
+//
+// Change messages can be configured with options:
+//
+//	msg, _ := state.Insert("user:123", user,
+//	    state.WithTxID("tx-001"),           // Group related changes
+//	    state.WithAutoTimestamp(),           // Add current timestamp
+//	)
+//
+// # Control Messages
+//
+// Control messages manage stream lifecycle:
+//
+//	state.SnapshotStart("offset")  // Begin snapshot
+//	state.SnapshotEnd("offset")    // End snapshot
+//	state.Reset("offset")          // Clear and restart
+//
+// # Publishing to ebu
+//
+// Change and control messages implement ebu's TypeNamer interface and can be
+// published directly:
+//
+//	bus := eventbus.New(eventbus.WithStore(store))
+//
+//	msg, _ := state.Insert("user:1", User{Name: "Alice"})
+//	eventbus.Publish(bus, msg)
+//
+// # Materialization
+//
+// The Materializer processes state protocol messages and builds state:
+//
+//	// Create materializer
+//	mat := state.NewMaterializer(
+//	    state.WithOnReset(func() { log.Println("State reset") }),
+//	)
+//
+//	// Register typed collections
+//	userStore := state.NewMemoryStore[User]()
+//	users := state.NewTypedCollection[User](userStore)
+//	state.RegisterCollection(mat, users)
+//
+//	// Replay events through the materializer
+//	mat.Replay(ctx, bus, eventbus.OffsetOldest)
+//
+//	// Access materialized state
+//	user, ok := users.Get("user:123")
+//
+// # Custom Type Names
+//
+// Entity types can implement TypeNamer for stable, explicit type names:
+//
+//	type User struct {
+//	    Name  string `json:"name"`
+//	    Email string `json:"email"`
+//	}
+//
+//	func (u User) StateTypeName() string { return "user" }
+//
+// This ensures type names remain stable across refactoring and package moves.
+//
+// # JSON Interoperability
+//
+// All messages serialize to JSON in a format compatible with the durable-streams
+// ecosystem. This enables interoperability with other implementations of the
+// State Protocol.
+//
+// For more information on the State Protocol, see:
+// https://github.com/durable-streams/durable-streams
+package state

--- a/state/helpers.go
+++ b/state/helpers.go
@@ -1,0 +1,145 @@
+package state
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Insert creates an insert change message for an entity.
+// The type parameter T determines the entity type name (unless overridden with WithEntityType).
+//
+// Example:
+//
+//	msg, err := state.Insert("user:1", User{Name: "Alice"})
+func Insert[T any](key string, value T, opts ...ChangeOption) (*ChangeMessage, error) {
+	return newChangeMessage[T](OperationInsert, key, &value, nil, opts...)
+}
+
+// Update creates an update change message for an entity.
+// The type parameter T determines the entity type name (unless overridden with WithEntityType).
+//
+// Example:
+//
+//	msg, err := state.Update("user:1", User{Name: "Alice Smith"})
+func Update[T any](key string, value T, opts ...ChangeOption) (*ChangeMessage, error) {
+	return newChangeMessage[T](OperationUpdate, key, &value, nil, opts...)
+}
+
+// UpdateWithOldValue creates an update change message with the old value for conflict detection.
+// The old value can be used by consumers to detect concurrent modifications.
+//
+// Example:
+//
+//	msg, err := state.UpdateWithOldValue("user:1", newUser, oldUser)
+func UpdateWithOldValue[T any](key string, value, oldValue T, opts ...ChangeOption) (*ChangeMessage, error) {
+	return newChangeMessage[T](OperationUpdate, key, &value, &oldValue, opts...)
+}
+
+// Delete creates a delete change message for an entity.
+// The type parameter T determines the entity type name.
+//
+// Example:
+//
+//	msg, err := state.Delete[User]("user:1")
+func Delete[T any](key string, opts ...ChangeOption) (*ChangeMessage, error) {
+	return newChangeMessage[T](OperationDelete, key, nil, nil, opts...)
+}
+
+// DeleteWithOldValue creates a delete change message with the old value preserved.
+// This is useful for consumers that need to know what was deleted.
+//
+// Example:
+//
+//	msg, err := state.DeleteWithOldValue("user:1", user)
+func DeleteWithOldValue[T any](key string, oldValue T, opts ...ChangeOption) (*ChangeMessage, error) {
+	return newChangeMessage[T](OperationDelete, key, nil, &oldValue, opts...)
+}
+
+// newChangeMessage is the internal constructor for change messages.
+func newChangeMessage[T any](op Operation, key string, value, oldValue *T, opts ...ChangeOption) (*ChangeMessage, error) {
+	if key == "" {
+		return nil, fmt.Errorf("state: key cannot be empty")
+	}
+
+	cfg := &changeConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	// Determine entity type
+	var zero T
+	entityType := EntityType(zero)
+	if cfg.entityType != "" {
+		entityType = cfg.entityType
+	}
+
+	msg := &ChangeMessage{
+		Type: entityType,
+		Key:  key,
+		Headers: Headers{
+			Operation: op,
+			TxID:      cfg.txID,
+		},
+	}
+
+	// Set timestamp
+	if cfg.timestamp != nil {
+		msg.Headers.Timestamp = cfg.timestamp.Format(time.RFC3339Nano)
+	} else if cfg.autoTimestamp {
+		msg.Headers.Timestamp = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+
+	// Marshal value for insert/update
+	if value != nil {
+		valueData, err := json.Marshal(value)
+		if err != nil {
+			return nil, fmt.Errorf("state: marshal value: %w", err)
+		}
+		msg.Value = valueData
+	}
+
+	// Marshal old value if provided
+	if oldValue != nil {
+		oldData, err := json.Marshal(oldValue)
+		if err != nil {
+			return nil, fmt.Errorf("state: marshal old_value: %w", err)
+		}
+		msg.OldValue = oldData
+	}
+
+	return msg, nil
+}
+
+// SnapshotStart creates a snapshot-start control message.
+// This marks the beginning of a snapshot in the stream.
+func SnapshotStart(offset string) *ControlMessage {
+	return &ControlMessage{
+		Headers: ControlHeaders{
+			Control: ControlSnapshotStart,
+			Offset:  offset,
+		},
+	}
+}
+
+// SnapshotEnd creates a snapshot-end control message.
+// This marks the end of a snapshot in the stream.
+func SnapshotEnd(offset string) *ControlMessage {
+	return &ControlMessage{
+		Headers: ControlHeaders{
+			Control: ControlSnapshotEnd,
+			Offset:  offset,
+		},
+	}
+}
+
+// Reset creates a reset control message.
+// This signals that all state should be cleared and rebuilt from subsequent events.
+func Reset(offset string) *ControlMessage {
+	return &ControlMessage{
+		Headers: ControlHeaders{
+			Control: ControlReset,
+			Offset:  offset,
+		},
+	}
+}

--- a/state/materializer.go
+++ b/state/materializer.go
@@ -200,7 +200,9 @@ func (m *Materializer) Apply(event *eventbus.StoredEvent) error {
 	var ctrlHeaders ControlHeaders
 	if json.Unmarshal(raw.Headers, &ctrlHeaders) == nil && ctrlHeaders.Control != "" {
 		m.applyControl(&ControlMessage{Headers: ctrlHeaders})
+		m.mu.Lock()
 		m.lastOffset = event.Offset
+		m.mu.Unlock()
 		return nil
 	}
 
@@ -214,7 +216,9 @@ func (m *Materializer) Apply(event *eventbus.StoredEvent) error {
 		return err
 	}
 
+	m.mu.Lock()
 	m.lastOffset = event.Offset
+	m.mu.Unlock()
 	return nil
 }
 
@@ -280,6 +284,8 @@ func (m *Materializer) applyControl(msg *ControlMessage) {
 
 // LastOffset returns the offset of the last applied event.
 func (m *Materializer) LastOffset() eventbus.Offset {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	return m.lastOffset
 }
 

--- a/state/materializer.go
+++ b/state/materializer.go
@@ -1,0 +1,290 @@
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	eventbus "github.com/jilio/ebu"
+)
+
+// Store is a generic interface for state storage.
+// Implementations can use any backing store (memory, database, etc.).
+type Store[T any] interface {
+	// Get retrieves an entity by its composite key.
+	Get(compositeKey string) (T, bool)
+	// Set stores an entity with the given composite key.
+	Set(compositeKey string, value T)
+	// Delete removes an entity by its composite key.
+	Delete(compositeKey string)
+	// Clear removes all entities from the store.
+	Clear()
+	// All returns a copy of all entities in the store.
+	All() map[string]T
+}
+
+// MemoryStore is an in-memory implementation of Store.
+// It is safe for concurrent access.
+type MemoryStore[T any] struct {
+	data map[string]T
+	mu   sync.RWMutex
+}
+
+// NewMemoryStore creates a new in-memory store.
+func NewMemoryStore[T any]() *MemoryStore[T] {
+	return &MemoryStore[T]{
+		data: make(map[string]T),
+	}
+}
+
+// Get retrieves an entity by its composite key.
+func (s *MemoryStore[T]) Get(key string) (T, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	v, ok := s.data[key]
+	return v, ok
+}
+
+// Set stores an entity with the given composite key.
+func (s *MemoryStore[T]) Set(key string, value T) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[key] = value
+}
+
+// Delete removes an entity by its composite key.
+func (s *MemoryStore[T]) Delete(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, key)
+}
+
+// Clear removes all entities from the store.
+func (s *MemoryStore[T]) Clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data = make(map[string]T)
+}
+
+// All returns a copy of all entities in the store.
+func (s *MemoryStore[T]) All() map[string]T {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make(map[string]T, len(s.data))
+	for k, v := range s.data {
+		result[k] = v
+	}
+	return result
+}
+
+// TypedCollection provides type-safe access to a collection of entities.
+// It wraps a Store and associates it with a specific entity type.
+type TypedCollection[T any] struct {
+	store      Store[T]
+	entityType string
+}
+
+// NewTypedCollection creates a collection for a specific entity type.
+// The entity type name is determined from the type parameter T.
+func NewTypedCollection[T any](store Store[T]) *TypedCollection[T] {
+	var zero T
+	return &TypedCollection[T]{
+		store:      store,
+		entityType: EntityType(zero),
+	}
+}
+
+// NewTypedCollectionWithType creates a collection with an explicit type name.
+// Use this when the type name should differ from the Go type name.
+func NewTypedCollectionWithType[T any](store Store[T], entityType string) *TypedCollection[T] {
+	return &TypedCollection[T]{
+		store:      store,
+		entityType: entityType,
+	}
+}
+
+// EntityType returns the entity type name for this collection.
+func (c *TypedCollection[T]) EntityType() string {
+	return c.entityType
+}
+
+// Get retrieves an entity by its key (without the type prefix).
+func (c *TypedCollection[T]) Get(key string) (T, bool) {
+	return c.store.Get(CompositeKey(c.entityType, key))
+}
+
+// All returns all entities in this collection.
+// The keys in the returned map are composite keys (type/key).
+func (c *TypedCollection[T]) All() map[string]T {
+	return c.store.All()
+}
+
+// collectionApplier is an internal interface for applying changes to collections.
+type collectionApplier interface {
+	applyChange(msg *ChangeMessage) error
+	clear()
+}
+
+// typedCollectionApplier wraps TypedCollection to implement collectionApplier.
+type typedCollectionApplier[T any] struct {
+	collection *TypedCollection[T]
+}
+
+func (a *typedCollectionApplier[T]) applyChange(msg *ChangeMessage) error {
+	key := CompositeKey(msg.Type, msg.Key)
+
+	switch msg.Headers.Operation {
+	case OperationInsert, OperationUpdate:
+		var value T
+		if err := json.Unmarshal(msg.Value, &value); err != nil {
+			return fmt.Errorf("state: unmarshal value for %s/%s: %w", msg.Type, msg.Key, err)
+		}
+		a.collection.store.Set(key, value)
+
+	case OperationDelete:
+		a.collection.store.Delete(key)
+	}
+
+	return nil
+}
+
+func (a *typedCollectionApplier[T]) clear() {
+	a.collection.store.Clear()
+}
+
+// Materializer processes state protocol messages and maintains state.
+// It applies change messages to registered collections and handles control messages.
+type Materializer struct {
+	collections map[string]collectionApplier
+	cfg         *materializerConfig
+	mu          sync.RWMutex
+	lastOffset  eventbus.Offset
+}
+
+// NewMaterializer creates a new Materializer.
+func NewMaterializer(opts ...MaterializerOption) *Materializer {
+	cfg := &materializerConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	return &Materializer{
+		collections: make(map[string]collectionApplier),
+		cfg:         cfg,
+	}
+}
+
+// RegisterCollection registers a typed collection with the materializer.
+// The collection's entity type determines which change messages are routed to it.
+func RegisterCollection[T any](m *Materializer, collection *TypedCollection[T]) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.collections[collection.EntityType()] = &typedCollectionApplier[T]{collection: collection}
+}
+
+// Apply processes a single StoredEvent containing a state protocol message.
+// This is the primary integration point with ebu's Replay functionality.
+//
+// The event's Data field should contain a JSON-encoded ChangeMessage or ControlMessage.
+func (m *Materializer) Apply(event *eventbus.StoredEvent) error {
+	// Determine message type by checking for control header
+	var raw struct {
+		Headers json.RawMessage `json:"headers"`
+	}
+	if err := json.Unmarshal(event.Data, &raw); err != nil {
+		return fmt.Errorf("state: unmarshal event: %w", err)
+	}
+
+	// Try to parse as control message first
+	var ctrlHeaders ControlHeaders
+	if json.Unmarshal(raw.Headers, &ctrlHeaders) == nil && ctrlHeaders.Control != "" {
+		m.applyControl(&ControlMessage{Headers: ctrlHeaders})
+		m.lastOffset = event.Offset
+		return nil
+	}
+
+	// Parse as change message
+	var changeMsg ChangeMessage
+	if err := json.Unmarshal(event.Data, &changeMsg); err != nil {
+		return fmt.Errorf("state: unmarshal change message: %w", err)
+	}
+
+	if err := m.applyChange(&changeMsg); err != nil {
+		return err
+	}
+
+	m.lastOffset = event.Offset
+	return nil
+}
+
+// ApplyChangeMessage processes a ChangeMessage directly.
+// Use this when you have a ChangeMessage that's not wrapped in a StoredEvent.
+func (m *Materializer) ApplyChangeMessage(msg *ChangeMessage) error {
+	return m.applyChange(msg)
+}
+
+// ApplyControlMessage processes a ControlMessage directly.
+// Use this when you have a ControlMessage that's not wrapped in a StoredEvent.
+func (m *Materializer) ApplyControlMessage(msg *ControlMessage) {
+	m.applyControl(msg)
+}
+
+// applyChange applies a change message to the appropriate collection.
+func (m *Materializer) applyChange(msg *ChangeMessage) error {
+	m.mu.RLock()
+	collection, ok := m.collections[msg.Type]
+	m.mu.RUnlock()
+
+	if !ok {
+		if m.cfg.strictSchema {
+			return fmt.Errorf("state: unknown entity type: %s", msg.Type)
+		}
+		return nil // Ignore unknown types in non-strict mode
+	}
+
+	if err := collection.applyChange(msg); err != nil {
+		if m.cfg.onError != nil {
+			m.cfg.onError(err)
+		}
+		return err
+	}
+
+	return nil
+}
+
+// applyControl applies a control message.
+func (m *Materializer) applyControl(msg *ControlMessage) {
+	switch msg.Headers.Control {
+	case ControlReset:
+		m.mu.Lock()
+		for _, c := range m.collections {
+			c.clear()
+		}
+		m.mu.Unlock()
+		if m.cfg.onReset != nil {
+			m.cfg.onReset()
+		}
+
+	case ControlSnapshotStart:
+		if m.cfg.onSnapshot != nil {
+			m.cfg.onSnapshot(true)
+		}
+
+	case ControlSnapshotEnd:
+		if m.cfg.onSnapshot != nil {
+			m.cfg.onSnapshot(false)
+		}
+	}
+}
+
+// LastOffset returns the offset of the last applied event.
+func (m *Materializer) LastOffset() eventbus.Offset {
+	return m.lastOffset
+}
+
+// Replay is a convenience method that replays events from an EventBus.
+// It calls bus.Replay and applies each event through the materializer.
+func (m *Materializer) Replay(ctx context.Context, bus *eventbus.EventBus, from eventbus.Offset) error {
+	return bus.Replay(ctx, from, m.Apply)
+}

--- a/state/message.go
+++ b/state/message.go
@@ -1,0 +1,109 @@
+package state
+
+import (
+	"encoding/json"
+	"reflect"
+)
+
+// Operation represents the type of change operation per the State Protocol.
+type Operation string
+
+const (
+	// OperationInsert indicates a new entity is being created.
+	OperationInsert Operation = "insert"
+	// OperationUpdate indicates an existing entity is being modified.
+	OperationUpdate Operation = "update"
+	// OperationDelete indicates an entity is being removed.
+	OperationDelete Operation = "delete"
+)
+
+// Control represents the type of control message per the State Protocol.
+type Control string
+
+const (
+	// ControlSnapshotStart marks the beginning of a snapshot.
+	ControlSnapshotStart Control = "snapshot-start"
+	// ControlSnapshotEnd marks the end of a snapshot.
+	ControlSnapshotEnd Control = "snapshot-end"
+	// ControlReset signals that all state should be cleared.
+	ControlReset Control = "reset"
+)
+
+// Headers contains metadata for change messages per the State Protocol.
+type Headers struct {
+	// Operation is the type of change (insert, update, delete).
+	Operation Operation `json:"operation"`
+	// TxID is an optional transaction identifier for grouping related changes.
+	TxID string `json:"txid,omitempty"`
+	// Timestamp is an optional RFC 3339 formatted timestamp.
+	Timestamp string `json:"timestamp,omitempty"`
+}
+
+// ControlHeaders contains metadata for control messages.
+type ControlHeaders struct {
+	// Control is the type of control message.
+	Control Control `json:"control"`
+	// Offset is an optional reference to a stream position.
+	Offset string `json:"offset,omitempty"`
+}
+
+// ChangeMessage represents a state change event per the State Protocol.
+// It contains an entity mutation (insert, update, or delete) with a composite key.
+type ChangeMessage struct {
+	// Type is the entity type discriminator (e.g., "user", "order").
+	Type string `json:"type"`
+	// Key is the unique identifier within the entity type.
+	Key string `json:"key"`
+	// Value contains the entity data (required for insert/update).
+	Value json.RawMessage `json:"value,omitempty"`
+	// OldValue contains the previous entity data (optional, for conflict detection).
+	OldValue json.RawMessage `json:"old_value,omitempty"`
+	// Headers contains operation metadata.
+	Headers Headers `json:"headers"`
+}
+
+// ControlMessage represents a control event per the State Protocol.
+// Control messages manage stream lifecycle (snapshots, resets).
+type ControlMessage struct {
+	// Headers contains control message metadata.
+	Headers ControlHeaders `json:"headers"`
+}
+
+// TypeNamer is an optional interface that entity types can implement to provide
+// their own type name. This mirrors ebu's TypeNamer pattern.
+//
+// Example:
+//
+//	type User struct { ... }
+//	func (u User) StateTypeName() string { return "user" }
+type TypeNamer interface {
+	StateTypeName() string
+}
+
+// EntityType returns the type name for an entity.
+// If the entity implements TypeNamer, returns the custom name.
+// Otherwise returns the reflect-based package-qualified name.
+func EntityType(entity any) string {
+	if namer, ok := entity.(TypeNamer); ok {
+		return namer.StateTypeName()
+	}
+	return reflect.TypeOf(entity).String()
+}
+
+// CompositeKey returns a composite key from type and key components.
+// The State Protocol uses type + key as a composite identifier.
+func CompositeKey(entityType, key string) string {
+	return entityType + "/" + key
+}
+
+// EventTypeName implements ebu's TypeNamer interface for ChangeMessage.
+// This allows ChangeMessage to be published directly to an EventBus.
+func (m ChangeMessage) EventTypeName() string {
+	return "state.ChangeMessage"
+}
+
+// EventTypeName implements ebu's TypeNamer interface for ControlMessage.
+// This allows ControlMessage to be published directly to an EventBus.
+func (m ControlMessage) EventTypeName() string {
+	return "state.ControlMessage"
+}

--- a/state/message.go
+++ b/state/message.go
@@ -83,7 +83,11 @@ type TypeNamer interface {
 // EntityType returns the type name for an entity.
 // If the entity implements TypeNamer, returns the custom name.
 // Otherwise returns the reflect-based package-qualified name.
+// Returns "nil" if entity is nil.
 func EntityType(entity any) string {
+	if entity == nil {
+		return "nil"
+	}
 	if namer, ok := entity.(TypeNamer); ok {
 		return namer.StateTypeName()
 	}

--- a/state/options.go
+++ b/state/options.go
@@ -1,0 +1,87 @@
+package state
+
+import "time"
+
+// ChangeOption configures a change message.
+type ChangeOption func(*changeConfig)
+
+type changeConfig struct {
+	txID          string
+	timestamp     *time.Time
+	autoTimestamp bool
+	entityType    string
+}
+
+// WithTxID sets the transaction ID for grouping related changes.
+// Transaction IDs allow consumers to process related changes atomically.
+func WithTxID(txID string) ChangeOption {
+	return func(c *changeConfig) {
+		c.txID = txID
+	}
+}
+
+// WithTimestamp sets an explicit timestamp for the change message.
+// The timestamp will be formatted as RFC 3339.
+func WithTimestamp(t time.Time) ChangeOption {
+	return func(c *changeConfig) {
+		c.timestamp = &t
+	}
+}
+
+// WithAutoTimestamp automatically sets the timestamp to the current time.
+func WithAutoTimestamp() ChangeOption {
+	return func(c *changeConfig) {
+		c.autoTimestamp = true
+	}
+}
+
+// WithEntityType overrides the automatic entity type name.
+// Use this when the type name should differ from the Go type name.
+func WithEntityType(typeName string) ChangeOption {
+	return func(c *changeConfig) {
+		c.entityType = typeName
+	}
+}
+
+// MaterializerOption configures a Materializer.
+type MaterializerOption func(*materializerConfig)
+
+type materializerConfig struct {
+	onReset      func()
+	onSnapshot   func(start bool)
+	onError      func(error)
+	strictSchema bool
+}
+
+// WithOnReset sets a callback invoked when a reset control message is received.
+// The callback is called after all collections have been cleared.
+func WithOnReset(fn func()) MaterializerOption {
+	return func(c *materializerConfig) {
+		c.onReset = fn
+	}
+}
+
+// WithOnSnapshot sets a callback invoked on snapshot-start/end messages.
+// The boolean parameter is true for snapshot-start, false for snapshot-end.
+func WithOnSnapshot(fn func(start bool)) MaterializerOption {
+	return func(c *materializerConfig) {
+		c.onSnapshot = fn
+	}
+}
+
+// WithOnError sets an error handler for materialization errors.
+// This is called when applying a change message fails.
+func WithOnError(fn func(error)) MaterializerOption {
+	return func(c *materializerConfig) {
+		c.onError = fn
+	}
+}
+
+// WithStrictSchema enables strict schema validation.
+// When enabled, the materializer returns an error for unknown entity types.
+// When disabled (default), unknown types are silently ignored.
+func WithStrictSchema() MaterializerOption {
+	return func(c *materializerConfig) {
+		c.strictSchema = true
+	}
+}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -59,6 +59,14 @@ func TestCompositeKey(t *testing.T) {
 	}
 }
 
+func TestEntityTypeWithNil(t *testing.T) {
+	got := EntityType(nil)
+	want := "nil"
+	if got != want {
+		t.Errorf("EntityType(nil) = %q, want %q", got, want)
+	}
+}
+
 func TestChangeMessageEventTypeName(t *testing.T) {
 	msg := ChangeMessage{}
 	got := msg.EventTypeName()

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1,0 +1,1017 @@
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	eventbus "github.com/jilio/ebu"
+)
+
+// Test entity types
+type User struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+type Product struct {
+	ID    string  `json:"id"`
+	Name  string  `json:"name"`
+	Price float64 `json:"price"`
+}
+
+// TypeNamer implementation for stable type names
+type NamedUser struct {
+	Name string `json:"name"`
+}
+
+func (u NamedUser) StateTypeName() string { return "user" }
+
+// ================== Message Type Tests ==================
+
+func TestEntityType(t *testing.T) {
+	t.Run("without TypeNamer", func(t *testing.T) {
+		user := User{Name: "Alice"}
+		got := EntityType(user)
+		want := "state.User"
+		if got != want {
+			t.Errorf("EntityType() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("with TypeNamer", func(t *testing.T) {
+		user := NamedUser{Name: "Alice"}
+		got := EntityType(user)
+		want := "user"
+		if got != want {
+			t.Errorf("EntityType() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestCompositeKey(t *testing.T) {
+	got := CompositeKey("user", "123")
+	want := "user/123"
+	if got != want {
+		t.Errorf("CompositeKey() = %q, want %q", got, want)
+	}
+}
+
+func TestChangeMessageEventTypeName(t *testing.T) {
+	msg := ChangeMessage{}
+	got := msg.EventTypeName()
+	want := "state.ChangeMessage"
+	if got != want {
+		t.Errorf("EventTypeName() = %q, want %q", got, want)
+	}
+}
+
+func TestControlMessageEventTypeName(t *testing.T) {
+	msg := ControlMessage{}
+	got := msg.EventTypeName()
+	want := "state.ControlMessage"
+	if got != want {
+		t.Errorf("EventTypeName() = %q, want %q", got, want)
+	}
+}
+
+// ================== Helper Function Tests ==================
+
+func TestInsert(t *testing.T) {
+	user := User{Name: "Alice", Email: "alice@example.com"}
+	msg, err := Insert("user:1", user)
+	if err != nil {
+		t.Fatalf("Insert() error = %v", err)
+	}
+
+	if msg.Type != "state.User" {
+		t.Errorf("Type = %q, want %q", msg.Type, "state.User")
+	}
+	if msg.Key != "user:1" {
+		t.Errorf("Key = %q, want %q", msg.Key, "user:1")
+	}
+	if msg.Headers.Operation != OperationInsert {
+		t.Errorf("Operation = %q, want %q", msg.Headers.Operation, OperationInsert)
+	}
+	if msg.Value == nil {
+		t.Error("Value should not be nil")
+	}
+	if msg.OldValue != nil {
+		t.Error("OldValue should be nil")
+	}
+
+	// Verify value can be unmarshaled
+	var decoded User
+	if err := json.Unmarshal(msg.Value, &decoded); err != nil {
+		t.Errorf("Unmarshal value: %v", err)
+	}
+	if decoded.Name != user.Name {
+		t.Errorf("decoded.Name = %q, want %q", decoded.Name, user.Name)
+	}
+}
+
+func TestInsertWithTypeName(t *testing.T) {
+	user := NamedUser{Name: "Alice"}
+	msg, err := Insert("user:1", user)
+	if err != nil {
+		t.Fatalf("Insert() error = %v", err)
+	}
+
+	if msg.Type != "user" {
+		t.Errorf("Type = %q, want %q", msg.Type, "user")
+	}
+}
+
+func TestInsertWithOptions(t *testing.T) {
+	user := User{Name: "Alice"}
+	ts := time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	msg, err := Insert("user:1", user,
+		WithTxID("tx-123"),
+		WithTimestamp(ts),
+		WithEntityType("custom.User"),
+	)
+	if err != nil {
+		t.Fatalf("Insert() error = %v", err)
+	}
+
+	if msg.Type != "custom.User" {
+		t.Errorf("Type = %q, want %q", msg.Type, "custom.User")
+	}
+	if msg.Headers.TxID != "tx-123" {
+		t.Errorf("TxID = %q, want %q", msg.Headers.TxID, "tx-123")
+	}
+	if msg.Headers.Timestamp != "2025-01-15T10:30:00Z" {
+		t.Errorf("Timestamp = %q, want %q", msg.Headers.Timestamp, "2025-01-15T10:30:00Z")
+	}
+}
+
+func TestInsertWithAutoTimestamp(t *testing.T) {
+	before := time.Now().UTC()
+	msg, err := Insert("user:1", User{Name: "Alice"}, WithAutoTimestamp())
+	after := time.Now().UTC()
+
+	if err != nil {
+		t.Fatalf("Insert() error = %v", err)
+	}
+
+	if msg.Headers.Timestamp == "" {
+		t.Error("Timestamp should be set")
+	}
+
+	ts, err := time.Parse(time.RFC3339Nano, msg.Headers.Timestamp)
+	if err != nil {
+		t.Errorf("Parse timestamp: %v", err)
+	}
+	if ts.Before(before) || ts.After(after) {
+		t.Errorf("Timestamp %v not between %v and %v", ts, before, after)
+	}
+}
+
+func TestInsertEmptyKey(t *testing.T) {
+	_, err := Insert("", User{Name: "Alice"})
+	if err == nil {
+		t.Error("Insert() with empty key should return error")
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	user := User{Name: "Alice Smith", Email: "alice.smith@example.com"}
+	msg, err := Update("user:1", user)
+	if err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+
+	if msg.Headers.Operation != OperationUpdate {
+		t.Errorf("Operation = %q, want %q", msg.Headers.Operation, OperationUpdate)
+	}
+	if msg.Value == nil {
+		t.Error("Value should not be nil")
+	}
+	if msg.OldValue != nil {
+		t.Error("OldValue should be nil")
+	}
+}
+
+func TestUpdateWithOldValue(t *testing.T) {
+	oldUser := User{Name: "Alice", Email: "alice@example.com"}
+	newUser := User{Name: "Alice Smith", Email: "alice.smith@example.com"}
+	msg, err := UpdateWithOldValue("user:1", newUser, oldUser)
+	if err != nil {
+		t.Fatalf("UpdateWithOldValue() error = %v", err)
+	}
+
+	if msg.Headers.Operation != OperationUpdate {
+		t.Errorf("Operation = %q, want %q", msg.Headers.Operation, OperationUpdate)
+	}
+	if msg.Value == nil {
+		t.Error("Value should not be nil")
+	}
+	if msg.OldValue == nil {
+		t.Error("OldValue should not be nil")
+	}
+
+	var decoded User
+	if err := json.Unmarshal(msg.OldValue, &decoded); err != nil {
+		t.Errorf("Unmarshal old_value: %v", err)
+	}
+	if decoded.Name != oldUser.Name {
+		t.Errorf("decoded.Name = %q, want %q", decoded.Name, oldUser.Name)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	msg, err := Delete[User]("user:1")
+	if err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	if msg.Type != "state.User" {
+		t.Errorf("Type = %q, want %q", msg.Type, "state.User")
+	}
+	if msg.Key != "user:1" {
+		t.Errorf("Key = %q, want %q", msg.Key, "user:1")
+	}
+	if msg.Headers.Operation != OperationDelete {
+		t.Errorf("Operation = %q, want %q", msg.Headers.Operation, OperationDelete)
+	}
+	if msg.Value != nil {
+		t.Error("Value should be nil for delete")
+	}
+	if msg.OldValue != nil {
+		t.Error("OldValue should be nil")
+	}
+}
+
+func TestDeleteWithOldValue(t *testing.T) {
+	user := User{Name: "Alice"}
+	msg, err := DeleteWithOldValue("user:1", user)
+	if err != nil {
+		t.Fatalf("DeleteWithOldValue() error = %v", err)
+	}
+
+	if msg.Headers.Operation != OperationDelete {
+		t.Errorf("Operation = %q, want %q", msg.Headers.Operation, OperationDelete)
+	}
+	if msg.Value != nil {
+		t.Error("Value should be nil for delete")
+	}
+	if msg.OldValue == nil {
+		t.Error("OldValue should not be nil")
+	}
+}
+
+func TestSnapshotStart(t *testing.T) {
+	msg := SnapshotStart("offset-123")
+	if msg.Headers.Control != ControlSnapshotStart {
+		t.Errorf("Control = %q, want %q", msg.Headers.Control, ControlSnapshotStart)
+	}
+	if msg.Headers.Offset != "offset-123" {
+		t.Errorf("Offset = %q, want %q", msg.Headers.Offset, "offset-123")
+	}
+}
+
+func TestSnapshotEnd(t *testing.T) {
+	msg := SnapshotEnd("offset-456")
+	if msg.Headers.Control != ControlSnapshotEnd {
+		t.Errorf("Control = %q, want %q", msg.Headers.Control, ControlSnapshotEnd)
+	}
+	if msg.Headers.Offset != "offset-456" {
+		t.Errorf("Offset = %q, want %q", msg.Headers.Offset, "offset-456")
+	}
+}
+
+func TestReset(t *testing.T) {
+	msg := Reset("offset-789")
+	if msg.Headers.Control != ControlReset {
+		t.Errorf("Control = %q, want %q", msg.Headers.Control, ControlReset)
+	}
+	if msg.Headers.Offset != "offset-789" {
+		t.Errorf("Offset = %q, want %q", msg.Headers.Offset, "offset-789")
+	}
+}
+
+// ================== MemoryStore Tests ==================
+
+func TestMemoryStore(t *testing.T) {
+	store := NewMemoryStore[User]()
+
+	// Test Set and Get
+	user := User{Name: "Alice", Email: "alice@example.com"}
+	store.Set("user/1", user)
+
+	got, ok := store.Get("user/1")
+	if !ok {
+		t.Error("Get() should find user")
+	}
+	if got.Name != user.Name {
+		t.Errorf("Name = %q, want %q", got.Name, user.Name)
+	}
+
+	// Test Get non-existent
+	_, ok = store.Get("user/999")
+	if ok {
+		t.Error("Get() should not find non-existent user")
+	}
+
+	// Test Delete
+	store.Delete("user/1")
+	_, ok = store.Get("user/1")
+	if ok {
+		t.Error("Get() should not find deleted user")
+	}
+
+	// Test All
+	store.Set("user/1", User{Name: "Alice"})
+	store.Set("user/2", User{Name: "Bob"})
+	all := store.All()
+	if len(all) != 2 {
+		t.Errorf("All() returned %d items, want 2", len(all))
+	}
+
+	// Test Clear
+	store.Clear()
+	all = store.All()
+	if len(all) != 0 {
+		t.Errorf("All() returned %d items after Clear, want 0", len(all))
+	}
+}
+
+// ================== TypedCollection Tests ==================
+
+func TestTypedCollection(t *testing.T) {
+	store := NewMemoryStore[User]()
+	users := NewTypedCollection[User](store)
+
+	if users.EntityType() != "state.User" {
+		t.Errorf("EntityType() = %q, want %q", users.EntityType(), "state.User")
+	}
+
+	// Store uses composite keys
+	store.Set(CompositeKey("state.User", "1"), User{Name: "Alice"})
+
+	// Collection uses simple keys
+	user, ok := users.Get("1")
+	if !ok {
+		t.Error("Get() should find user")
+	}
+	if user.Name != "Alice" {
+		t.Errorf("Name = %q, want %q", user.Name, "Alice")
+	}
+}
+
+func TestTypedCollectionWithType(t *testing.T) {
+	store := NewMemoryStore[User]()
+	users := NewTypedCollectionWithType[User](store, "custom.User")
+
+	if users.EntityType() != "custom.User" {
+		t.Errorf("EntityType() = %q, want %q", users.EntityType(), "custom.User")
+	}
+}
+
+// ================== Materializer Tests ==================
+
+func TestMaterializerApplyInsert(t *testing.T) {
+	mat := NewMaterializer()
+	store := NewMemoryStore[User]()
+	users := NewTypedCollection[User](store)
+	RegisterCollection(mat, users)
+
+	// Create insert message
+	insertData, _ := json.Marshal(&ChangeMessage{
+		Type:    "state.User",
+		Key:     "1",
+		Value:   json.RawMessage(`{"name":"Alice","email":"alice@example.com"}`),
+		Headers: Headers{Operation: OperationInsert},
+	})
+
+	event := &eventbus.StoredEvent{
+		Offset: "1",
+		Type:   "state.ChangeMessage",
+		Data:   insertData,
+	}
+
+	if err := mat.Apply(event); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	user, ok := users.Get("1")
+	if !ok {
+		t.Error("User not found after insert")
+	}
+	if user.Name != "Alice" {
+		t.Errorf("Name = %q, want %q", user.Name, "Alice")
+	}
+}
+
+func TestMaterializerApplyUpdate(t *testing.T) {
+	mat := NewMaterializer()
+	store := NewMemoryStore[User]()
+	users := NewTypedCollection[User](store)
+	RegisterCollection(mat, users)
+
+	// Insert first
+	store.Set(CompositeKey("state.User", "1"), User{Name: "Alice"})
+
+	// Apply update
+	updateData, _ := json.Marshal(&ChangeMessage{
+		Type:    "state.User",
+		Key:     "1",
+		Value:   json.RawMessage(`{"name":"Alice Smith","email":"alice.smith@example.com"}`),
+		Headers: Headers{Operation: OperationUpdate},
+	})
+
+	event := &eventbus.StoredEvent{
+		Offset: "2",
+		Data:   updateData,
+	}
+
+	if err := mat.Apply(event); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	user, ok := users.Get("1")
+	if !ok {
+		t.Error("User not found after update")
+	}
+	if user.Name != "Alice Smith" {
+		t.Errorf("Name = %q, want %q", user.Name, "Alice Smith")
+	}
+}
+
+func TestMaterializerApplyDelete(t *testing.T) {
+	mat := NewMaterializer()
+	store := NewMemoryStore[User]()
+	users := NewTypedCollection[User](store)
+	RegisterCollection(mat, users)
+
+	// Insert first
+	store.Set(CompositeKey("state.User", "1"), User{Name: "Alice"})
+
+	// Apply delete
+	deleteData, _ := json.Marshal(&ChangeMessage{
+		Type:    "state.User",
+		Key:     "1",
+		Headers: Headers{Operation: OperationDelete},
+	})
+
+	event := &eventbus.StoredEvent{
+		Offset: "2",
+		Data:   deleteData,
+	}
+
+	if err := mat.Apply(event); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	_, ok := users.Get("1")
+	if ok {
+		t.Error("User should not exist after delete")
+	}
+}
+
+func TestMaterializerApplyReset(t *testing.T) {
+	resetCalled := false
+	mat := NewMaterializer(WithOnReset(func() {
+		resetCalled = true
+	}))
+
+	store := NewMemoryStore[User]()
+	users := NewTypedCollection[User](store)
+	RegisterCollection(mat, users)
+
+	// Insert some data
+	store.Set(CompositeKey("state.User", "1"), User{Name: "Alice"})
+	store.Set(CompositeKey("state.User", "2"), User{Name: "Bob"})
+
+	// Apply reset
+	resetData, _ := json.Marshal(&ControlMessage{
+		Headers: ControlHeaders{Control: ControlReset},
+	})
+
+	event := &eventbus.StoredEvent{
+		Offset: "3",
+		Data:   resetData,
+	}
+
+	if err := mat.Apply(event); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	if !resetCalled {
+		t.Error("OnReset callback was not called")
+	}
+
+	all := users.All()
+	if len(all) != 0 {
+		t.Errorf("Store should be empty after reset, got %d items", len(all))
+	}
+}
+
+func TestMaterializerApplySnapshot(t *testing.T) {
+	snapshotStarts := 0
+	snapshotEnds := 0
+	mat := NewMaterializer(WithOnSnapshot(func(start bool) {
+		if start {
+			snapshotStarts++
+		} else {
+			snapshotEnds++
+		}
+	}))
+
+	// Apply snapshot-start
+	startData, _ := json.Marshal(&ControlMessage{
+		Headers: ControlHeaders{Control: ControlSnapshotStart, Offset: "1"},
+	})
+	event1 := &eventbus.StoredEvent{Offset: "1", Data: startData}
+	if err := mat.Apply(event1); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	// Apply snapshot-end
+	endData, _ := json.Marshal(&ControlMessage{
+		Headers: ControlHeaders{Control: ControlSnapshotEnd, Offset: "10"},
+	})
+	event2 := &eventbus.StoredEvent{Offset: "10", Data: endData}
+	if err := mat.Apply(event2); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	if snapshotStarts != 1 {
+		t.Errorf("snapshotStarts = %d, want 1", snapshotStarts)
+	}
+	if snapshotEnds != 1 {
+		t.Errorf("snapshotEnds = %d, want 1", snapshotEnds)
+	}
+}
+
+func TestMaterializerUnknownType(t *testing.T) {
+	t.Run("non-strict mode ignores unknown types", func(t *testing.T) {
+		mat := NewMaterializer()
+
+		insertData, _ := json.Marshal(&ChangeMessage{
+			Type:    "unknown.Type",
+			Key:     "1",
+			Value:   json.RawMessage(`{"foo":"bar"}`),
+			Headers: Headers{Operation: OperationInsert},
+		})
+
+		event := &eventbus.StoredEvent{Offset: "1", Data: insertData}
+		err := mat.Apply(event)
+		if err != nil {
+			t.Errorf("Apply() should not error in non-strict mode, got %v", err)
+		}
+	})
+
+	t.Run("strict mode errors on unknown types", func(t *testing.T) {
+		mat := NewMaterializer(WithStrictSchema())
+
+		insertData, _ := json.Marshal(&ChangeMessage{
+			Type:    "unknown.Type",
+			Key:     "1",
+			Value:   json.RawMessage(`{"foo":"bar"}`),
+			Headers: Headers{Operation: OperationInsert},
+		})
+
+		event := &eventbus.StoredEvent{Offset: "1", Data: insertData}
+		err := mat.Apply(event)
+		if err == nil {
+			t.Error("Apply() should error in strict mode for unknown types")
+		}
+	})
+}
+
+func TestMaterializerOnError(t *testing.T) {
+	var capturedError error
+	mat := NewMaterializer(WithOnError(func(err error) {
+		capturedError = err
+	}))
+
+	store := NewMemoryStore[User]()
+	users := NewTypedCollection[User](store)
+	RegisterCollection(mat, users)
+
+	// Create event with value that is valid JSON but cannot be unmarshaled to User
+	// The value is a string instead of an object, which will fail unmarshal to User struct
+	insertData := []byte(`{"type":"state.User","key":"1","value":"not an object","headers":{"operation":"insert"}}`)
+
+	event := &eventbus.StoredEvent{Offset: "1", Data: insertData}
+	err := mat.Apply(event)
+	if err == nil {
+		t.Error("Apply() should error when value cannot be unmarshaled to target type")
+	}
+	if capturedError == nil {
+		t.Error("OnError callback was not called")
+	}
+}
+
+func TestMaterializerLastOffset(t *testing.T) {
+	mat := NewMaterializer()
+	store := NewMemoryStore[User]()
+	users := NewTypedCollection[User](store)
+	RegisterCollection(mat, users)
+
+	insertData, _ := json.Marshal(&ChangeMessage{
+		Type:    "state.User",
+		Key:     "1",
+		Value:   json.RawMessage(`{"name":"Alice"}`),
+		Headers: Headers{Operation: OperationInsert},
+	})
+
+	event := &eventbus.StoredEvent{Offset: "42", Data: insertData}
+	if err := mat.Apply(event); err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	if mat.LastOffset() != "42" {
+		t.Errorf("LastOffset() = %q, want %q", mat.LastOffset(), "42")
+	}
+}
+
+func TestMaterializerApplyChangeMessageDirectly(t *testing.T) {
+	mat := NewMaterializer()
+	store := NewMemoryStore[User]()
+	users := NewTypedCollection[User](store)
+	RegisterCollection(mat, users)
+
+	msg, _ := Insert("1", User{Name: "Alice"})
+	if err := mat.ApplyChangeMessage(msg); err != nil {
+		t.Fatalf("ApplyChangeMessage() error = %v", err)
+	}
+
+	user, ok := users.Get("1")
+	if !ok {
+		t.Error("User not found after insert")
+	}
+	if user.Name != "Alice" {
+		t.Errorf("Name = %q, want %q", user.Name, "Alice")
+	}
+}
+
+func TestMaterializerApplyControlMessageDirectly(t *testing.T) {
+	resetCalled := false
+	mat := NewMaterializer(WithOnReset(func() {
+		resetCalled = true
+	}))
+
+	store := NewMemoryStore[User]()
+	users := NewTypedCollection[User](store)
+	RegisterCollection(mat, users)
+
+	store.Set(CompositeKey("state.User", "1"), User{Name: "Alice"})
+
+	msg := Reset("offset-1")
+	mat.ApplyControlMessage(msg)
+
+	if !resetCalled {
+		t.Error("OnReset callback was not called")
+	}
+
+	all := users.All()
+	if len(all) != 0 {
+		t.Errorf("Store should be empty after reset, got %d items", len(all))
+	}
+}
+
+// ================== Integration Tests ==================
+
+func TestIntegrationWithEventBus(t *testing.T) {
+	// Create event bus with memory store
+	ebuStore := eventbus.NewMemoryStore()
+	bus := eventbus.New(eventbus.WithStore(ebuStore))
+
+	// Publish some state change events
+	ctx := context.Background()
+
+	msg1, _ := Insert("1", User{Name: "Alice", Email: "alice@example.com"})
+	eventbus.Publish(bus, msg1)
+
+	msg2, _ := Insert("2", User{Name: "Bob", Email: "bob@example.com"})
+	eventbus.Publish(bus, msg2)
+
+	msg3, _ := Update("1", User{Name: "Alice Smith", Email: "alice.smith@example.com"})
+	eventbus.Publish(bus, msg3)
+
+	msg4, _ := Delete[User]("2")
+	eventbus.Publish(bus, msg4)
+
+	// Create materializer and replay
+	mat := NewMaterializer()
+	store := NewMemoryStore[User]()
+	users := NewTypedCollection[User](store)
+	RegisterCollection(mat, users)
+
+	if err := mat.Replay(ctx, bus, eventbus.OffsetOldest); err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+
+	// Verify final state
+	user1, ok := users.Get("1")
+	if !ok {
+		t.Error("User 1 should exist")
+	}
+	if user1.Name != "Alice Smith" {
+		t.Errorf("User 1 name = %q, want %q", user1.Name, "Alice Smith")
+	}
+
+	_, ok = users.Get("2")
+	if ok {
+		t.Error("User 2 should not exist (was deleted)")
+	}
+}
+
+func TestIntegrationMultipleCollections(t *testing.T) {
+	ebuStore := eventbus.NewMemoryStore()
+	bus := eventbus.New(eventbus.WithStore(ebuStore))
+
+	ctx := context.Background()
+
+	// Publish users
+	userMsg, _ := Insert("1", User{Name: "Alice"}, WithEntityType("user"))
+	eventbus.Publish(bus, userMsg)
+
+	// Publish products
+	productMsg, _ := Insert("p1", Product{ID: "p1", Name: "Widget", Price: 9.99}, WithEntityType("product"))
+	eventbus.Publish(bus, productMsg)
+
+	// Create materializer with multiple collections
+	mat := NewMaterializer()
+
+	userStore := NewMemoryStore[User]()
+	users := NewTypedCollectionWithType[User](userStore, "user")
+	RegisterCollection(mat, users)
+
+	productStore := NewMemoryStore[Product]()
+	products := NewTypedCollectionWithType[Product](productStore, "product")
+	RegisterCollection(mat, products)
+
+	if err := mat.Replay(ctx, bus, eventbus.OffsetOldest); err != nil {
+		t.Fatalf("Replay() error = %v", err)
+	}
+
+	// Verify both collections
+	user, ok := users.Get("1")
+	if !ok {
+		t.Error("User should exist")
+	}
+	if user.Name != "Alice" {
+		t.Errorf("User name = %q, want %q", user.Name, "Alice")
+	}
+
+	product, ok := products.Get("p1")
+	if !ok {
+		t.Error("Product should exist")
+	}
+	if product.Name != "Widget" {
+		t.Errorf("Product name = %q, want %q", product.Name, "Widget")
+	}
+}
+
+// ================== JSON Conformance Tests ==================
+
+func TestJSONConformance(t *testing.T) {
+	t.Run("change message serialization", func(t *testing.T) {
+		msg, _ := Insert("user:1", User{Name: "Alice"}, WithTxID("tx-1"))
+		data, err := json.Marshal(msg)
+		if err != nil {
+			t.Fatalf("Marshal() error = %v", err)
+		}
+
+		// Verify expected fields are present
+		var raw map[string]interface{}
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatalf("Unmarshal() error = %v", err)
+		}
+
+		if raw["type"] != "state.User" {
+			t.Errorf("type = %v, want state.User", raw["type"])
+		}
+		if raw["key"] != "user:1" {
+			t.Errorf("key = %v, want user:1", raw["key"])
+		}
+
+		headers, ok := raw["headers"].(map[string]interface{})
+		if !ok {
+			t.Fatal("headers should be an object")
+		}
+		if headers["operation"] != "insert" {
+			t.Errorf("operation = %v, want insert", headers["operation"])
+		}
+		if headers["txid"] != "tx-1" {
+			t.Errorf("txid = %v, want tx-1", headers["txid"])
+		}
+	})
+
+	t.Run("control message serialization", func(t *testing.T) {
+		msg := Reset("offset-123")
+		data, err := json.Marshal(msg)
+		if err != nil {
+			t.Fatalf("Marshal() error = %v", err)
+		}
+
+		var raw map[string]interface{}
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatalf("Unmarshal() error = %v", err)
+		}
+
+		headers, ok := raw["headers"].(map[string]interface{})
+		if !ok {
+			t.Fatal("headers should be an object")
+		}
+		if headers["control"] != "reset" {
+			t.Errorf("control = %v, want reset", headers["control"])
+		}
+		if headers["offset"] != "offset-123" {
+			t.Errorf("offset = %v, want offset-123", headers["offset"])
+		}
+	})
+
+	t.Run("old_value uses snake_case", func(t *testing.T) {
+		msg, _ := UpdateWithOldValue("user:1",
+			User{Name: "New"},
+			User{Name: "Old"},
+		)
+		data, err := json.Marshal(msg)
+		if err != nil {
+			t.Fatalf("Marshal() error = %v", err)
+		}
+
+		// Check that old_value (snake_case) is used, not oldValue
+		if string(data) == "" {
+			t.Fatal("data should not be empty")
+		}
+
+		var raw map[string]interface{}
+		if err := json.Unmarshal(data, &raw); err != nil {
+			t.Fatalf("Unmarshal() error = %v", err)
+		}
+
+		if _, ok := raw["old_value"]; !ok {
+			t.Error("old_value field should be present")
+		}
+		if _, ok := raw["oldValue"]; ok {
+			t.Error("oldValue (camelCase) should not be present")
+		}
+	})
+}
+
+// ================== Concurrent Access Tests ==================
+
+func TestMemoryStoreConcurrentAccess(t *testing.T) {
+	store := NewMemoryStore[User]()
+	done := make(chan bool)
+
+	// Concurrent writes
+	go func() {
+		for i := 0; i < 100; i++ {
+			store.Set("user/1", User{Name: "Alice"})
+		}
+		done <- true
+	}()
+
+	// Concurrent reads
+	go func() {
+		for i := 0; i < 100; i++ {
+			store.Get("user/1")
+		}
+		done <- true
+	}()
+
+	// Concurrent All()
+	go func() {
+		for i := 0; i < 100; i++ {
+			store.All()
+		}
+		done <- true
+	}()
+
+	// Wait for all goroutines
+	<-done
+	<-done
+	<-done
+}
+
+func TestMaterializerConcurrentAccess(t *testing.T) {
+	mat := NewMaterializer()
+	store := NewMemoryStore[User]()
+	users := NewTypedCollection[User](store)
+	RegisterCollection(mat, users)
+
+	done := make(chan bool)
+	errChan := make(chan error, 100)
+
+	// Concurrent applies
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			for j := 0; j < 10; j++ {
+				msg, _ := Insert(string(rune('0'+id)), User{Name: "User"})
+				if err := mat.ApplyChangeMessage(msg); err != nil {
+					errChan <- err
+				}
+			}
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	close(errChan)
+	for err := range errChan {
+		t.Errorf("Concurrent apply error: %v", err)
+	}
+}
+
+// ================== Error Case Tests ==================
+
+type unmarshalableType struct {
+	Ch chan int // Channels cannot be marshaled to JSON
+}
+
+func TestInsertMarshalError(t *testing.T) {
+	_, err := Insert("key", unmarshalableType{Ch: make(chan int)})
+	if err == nil {
+		t.Error("Insert() should fail for unmarshalable type")
+	}
+}
+
+func TestUpdateWithOldValueMarshalError(t *testing.T) {
+	_, err := UpdateWithOldValue("key",
+		unmarshalableType{Ch: make(chan int)},
+		unmarshalableType{Ch: make(chan int)},
+	)
+	if err == nil {
+		t.Error("UpdateWithOldValue() should fail for unmarshalable old value")
+	}
+}
+
+type customError struct{}
+
+func (e customError) Error() string { return "custom error" }
+
+func TestMaterializerErrorPropagation(t *testing.T) {
+	mat := NewMaterializer()
+	store := NewMemoryStore[User]()
+	users := NewTypedCollection[User](store)
+	RegisterCollection(mat, users)
+
+	// Invalid JSON in value
+	insertData, _ := json.Marshal(&ChangeMessage{
+		Type:    "state.User",
+		Key:     "1",
+		Value:   json.RawMessage(`{invalid`),
+		Headers: Headers{Operation: OperationInsert},
+	})
+
+	event := &eventbus.StoredEvent{Offset: "1", Data: insertData}
+	err := mat.Apply(event)
+	if err == nil {
+		t.Error("Apply() should return error for invalid JSON")
+	}
+
+	// Verify it's wrapped correctly
+	var syntaxErr *json.SyntaxError
+	if !errors.As(err, &syntaxErr) {
+		t.Errorf("Error should wrap json.SyntaxError, got %T", err)
+	}
+}
+
+func TestDeleteWithOldValueMarshalError(t *testing.T) {
+	_, err := DeleteWithOldValue("key", unmarshalableType{Ch: make(chan int)})
+	if err == nil {
+		t.Error("DeleteWithOldValue() should fail for unmarshalable old value")
+	}
+}
+
+func TestApplyInvalidRootJSON(t *testing.T) {
+	mat := NewMaterializer()
+
+	// Completely invalid JSON at root level
+	event := &eventbus.StoredEvent{Offset: "1", Data: []byte(`{invalid`)}
+	err := mat.Apply(event)
+	if err == nil {
+		t.Error("Apply() should error on invalid root JSON")
+	}
+}
+
+func TestApplyInvalidChangeMessageJSON(t *testing.T) {
+	mat := NewMaterializer()
+	store := NewMemoryStore[User]()
+	users := NewTypedCollection[User](store)
+	RegisterCollection(mat, users)
+
+	// Valid headers structure but invalid change message structure
+	// The headers are valid but rest of message is malformed
+	event := &eventbus.StoredEvent{
+		Offset: "1",
+		Data:   []byte(`{"headers":{"operation":"insert"},"type":123,"key":"1"}`),
+	}
+	err := mat.Apply(event)
+	if err == nil {
+		t.Error("Apply() should error when type field is wrong type")
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds an optional `state/` package that implements the Durable Streams State Protocol for ebu, enabling database-style state synchronization on top of ebu's event-driven architecture.

## What's New

- **Type-safe helpers** using Go generics: `Insert`, `Update`, `Delete`, `UpdateWithOldValue`, `DeleteWithOldValue`
- **Options pattern** for configurable messages: `WithTxID`, `WithTimestamp`, `WithAutoTimestamp`, `WithEntityType`
- **Materializer** that processes state protocol messages and builds typed state from events
- **Store interface** with in-memory implementation for materializing state
- **TypedCollection** for type-safe access to entity collections
- Full JSON interoperability with durable-streams ecosystem
- 100% test coverage with comprehensive unit, integration, and conformance tests

## Design

The package is completely optional and doesn't modify core ebu. It integrates seamlessly with ebu's `Replay` functionality and event bus. Messages implement ebu's `TypeNamer` interface and can be published directly.

## Test Coverage

All 44 tests pass with 100% code coverage. Testing includes unit tests for all types and functions, integration tests with the event bus, JSON conformance tests, concurrent access tests, and error case coverage.

## Pre-Merge Verification

- ✅ `go fmt ./...` - code is properly formatted
- ✅ `go test ./...` - all tests pass  
- ✅ `go test -coverprofile=coverage.out ./state && go tool cover -func=coverage.out` - 100.0% coverage verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)