### PR TITLE
Reliability hardening: event envelope, strict persistence, TryPublish, subscription handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Event envelope: `ID`, `Origin`, `Metadata`.** Every persisted event now
+  carries a ULID `ID` minted once per publish (store-level retries reuse it,
+  so it is a reliable deduplication key for at-least-once delivery), the
+  publishing bus instance's `Origin` (`bus.OriginID()`), and optional
+  publisher-supplied `Metadata` attached with `ContextWithMetadata`. Live
+  handlers can read the ID and metadata with `EventIDFromContext` /
+  `MetadataFromContext`. All fields are optional on the wire, so existing
+  streams and external producers remain compatible. `NewEventID` (a
+  dependency-free ULID generator) is exported.
+- **`WithStrictPersistence`.** Makes persistence a delivery precondition: a
+  failed marshal or `Append` skips handler delivery, so handlers never
+  observe an event the log did not record and replay cannot diverge from
+  live handling. Default behavior (best-effort) is unchanged.
+- **`TryPublish` / `TryPublishContext`.** Publish variants that return the
+  persistence error, for publishers that must act on failure (e.g. fail the
+  originating request). Nil when persistence succeeded or no store is
+  configured.
+- **Subscription handles.** `SubscribeWithHandle` /
+  `SubscribeContextWithHandle` return a `*Subscription` whose `Unsubscribe`
+  removes exactly that registration by identity — closing the long-standing
+  `Unsubscribe` footgun where two closures from the same function literal
+  share a code pointer and cannot be told apart. Idempotent and safe for
+  concurrent use.
+- **sqlite: schema v4** adds nullable `event_id`, `origin`, and `metadata`
+  columns for the envelope. The migration tolerates concurrent migrators
+  (duplicate-column errors are treated as already-applied) and rows written
+  by earlier versions read back with empty envelope fields.
+- **durablestream: envelope fields** are written and read as optional JSON
+  keys (`id`, `origin`, `metadata`), byte-compatible with pre-envelope
+  streams.
+
+### Documented
+
+- `Async()` + `SubscribeWithReplay` offset saves can complete out of publish
+  order; delivery stays at-least-once but a crash may redeliver more history.
+  Prefer synchronous replay handlers or idempotency on `StoredEvent.ID`.
+
 ## [0.15.0] - 2026-07-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -174,13 +174,17 @@ if eventbus.HasHandlers[UserEvent](bus) {
     eventbus.Publish(bus, UserEvent{})
 }
 
-// Unsubscribe a handler
+// Unsubscribe precisely with a handle (recommended for closures)
+sub, _ := eventbus.SubscribeWithHandle(bus, func(event UserEvent) { /* ... */ })
+sub.Unsubscribe() // removes exactly this registration; idempotent
+
+// Or unsubscribe by handler reference
 handler := func(event UserEvent) { /* ... */ }
 eventbus.Subscribe(bus, handler)
 eventbus.Unsubscribe(bus, handler)
-// Note: handlers are matched by code pointer. Keep a reference to the
+// Note: Unsubscribe matches by code pointer. Keep a reference to the
 // exact handler you registered — two closures made from the same function
-// literal are indistinguishable.
+// literal are indistinguishable. Handles have no such ambiguity.
 
 // Clear all handlers for a type
 eventbus.Clear[UserEvent](bus)
@@ -223,6 +227,19 @@ eventbus.SubscribeWithReplay(ctx, bus, "email-sender",
   publish path *before* handlers run, but a failed `Append` does not stop
   delivery — the error goes to the `PersistenceErrorHandler`
   (`WithPersistenceErrorHandler`). Monitor it in production.
+- **Strict mode**: with `eventbus.WithStrictPersistence()`, a failed persist
+  *skips* delivery instead — handlers never observe an event the log did not
+  record, so replay can never diverge from what live handlers saw. Use it
+  when the store is the source of truth (event sourcing, shared logs).
+- **Publishers can observe the outcome**: `eventbus.TryPublish` /
+  `eventbus.TryPublishContext` return the persistence error (nil on success
+  or when no store is configured), so a request handler can fail the request
+  when its event was not durably recorded.
+- **Every persisted event carries an envelope**: a ULID `ID` (minted once per
+  publish — store-level retries reuse it, making it a reliable dedup key), the
+  publishing bus's `Origin`, and optional publisher `Metadata` attached via
+  `eventbus.ContextWithMetadata(ctx, map[string]string{...})`. Live handlers
+  can read the ID with `eventbus.EventIDFromContext(ctx)`.
 - **`SubscribeWithReplay` is at-least-once**: each handled event saves its own
   offset after the handler returns. If the process crashes between handling
   and the offset save, that event is redelivered on the next start — make
@@ -234,6 +251,11 @@ eventbus.SubscribeWithReplay(ctx, bus, "email-sender",
   `PersistenceErrorHandler` (as its `*StoredEvent`, so the payload can be
   parked elsewhere), its offset is saved so the skip is durable across
   restarts, and replay continues.
+- **`Async()` + `SubscribeWithReplay`**: offset saves for an async
+  subscription run concurrently and can complete out of publish order, so a
+  crash may redeliver a little more history than with a synchronous handler.
+  Still at-least-once — but prefer synchronous replay handlers, or make them
+  idempotent on `StoredEvent.ID`.
 - **Validation before replay**: `SubscribeWithReplay` validates all arguments
   and options (including the `WithFilter` predicate's type) before the replay
   pass — a call that returns a validation error has delivered nothing and

--- a/docs/PERSISTENCE.md
+++ b/docs/PERSISTENCE.md
@@ -95,14 +95,17 @@ bus := eventbus.New(eventbus.WithStore(store))
 
 ### StoredEvent Structure
 
-Events are stored with metadata:
+Events are stored with an envelope:
 
 ```go
 type StoredEvent struct {
-    Offset    Offset          // Opaque position in the stream
-    Type      string          // Event type name (e.g., "main.UserCreatedEvent")
-    Data      json.RawMessage // JSON-encoded event data
-    Timestamp time.Time       // When the event was stored
+    Offset    Offset            // Opaque position in the stream
+    ID        string            // ULID assigned per publish (dedup/idempotency key)
+    Origin    string            // ID of the bus instance that published it
+    Type      string            // Event type name (e.g., "main.UserCreatedEvent")
+    Data      json.RawMessage   // JSON-encoded event data
+    Metadata  map[string]string // Publisher-supplied metadata (see ContextWithMetadata)
+    Timestamp time.Time         // When the event was stored
 }
 
 // Special offset constants
@@ -111,6 +114,24 @@ const (
     OffsetNewest Offset = "$"  // Current end of stream
 )
 ```
+
+The envelope makes at-least-once delivery workable in practice:
+
+- **`ID`** is a ULID minted once per publish, *before* the first `Append`
+  attempt — a store that retries a failed append writes the same ID, so
+  consumers can deduplicate on it. Handlers of live events can read it with
+  `EventIDFromContext(ctx)`.
+- **`Origin`** is the publishing bus instance's unique ID (`bus.OriginID()`),
+  letting consumers of a shared log tell their own events apart from a
+  peer process's.
+- **`Metadata`** carries correlation/causation IDs or any other tags:
+  attach with `ContextWithMetadata(ctx, map[string]string{...})` at publish,
+  read back via `StoredEvent.Metadata` or `MetadataFromContext(ctx)` in
+  live handlers.
+
+All three fields are optional on the wire (`omitempty`, nullable columns), so
+streams written by earlier ebu versions or external producers read back with
+empty envelope fields.
 
 `OffsetNewest` resolves, at call time, to the concrete current tail in every
 bundled store: reading from it returns no historical events and a concrete
@@ -338,7 +359,12 @@ eventbus.SubscribeWithReplay(ctx, bus, "analytics", analyticsHandler)
 
 ### EventStore Interface
 
-Implement this interface for custom storage backends:
+Implement this interface for custom storage backends. Persist the whole
+envelope — `ID`, `Origin`, and `Metadata` alongside `Type`/`Data`/`Timestamp`
+— and copy it back onto the `StoredEvent`s you return, or consumers lose
+their deduplication and correlation keys (the bundled stores all do this;
+the Postgres example below predates the envelope and stores only the core
+fields):
 
 ```go
 // EventStore is the core interface (2 methods)

--- a/event_bus.go
+++ b/event_bus.go
@@ -83,6 +83,16 @@ type EventBus struct {
 	persistenceTimeout      time.Duration
 	replayBatchSize         int // Batch size for Replay (default: 100)
 
+	// strictPersistence, when set, makes a failed Append stop delivery:
+	// handlers never observe an event the log did not record (see
+	// WithStrictPersistence).
+	strictPersistence bool
+
+	// originID uniquely identifies this bus instance; it is stamped on every
+	// persisted event's Origin field so processes sharing a log can tell
+	// their own events apart from a peer's.
+	originID string
+
 	// Upcast registry for event migration
 	upcastRegistry *upcastRegistry
 
@@ -195,6 +205,7 @@ type Option func(*EventBus)
 func New(opts ...Option) *EventBus {
 	bus := &EventBus{
 		upcastRegistry: newUpcastRegistry(),
+		originID:       NewEventID(),
 	}
 	bus.asyncCond = sync.NewCond(&bus.asyncMu)
 
@@ -256,6 +267,95 @@ func (bus *EventBus) addHandler(eventType reflect.Type, h *internalHandler) {
 	shard.mu.Lock()
 	shard.handlers[eventType] = append(shard.handlers[eventType], h)
 	shard.mu.Unlock()
+}
+
+// removeHandler unregisters a handler by identity (pointer equality on the
+// internalHandler), which — unlike Unsubscribe's code-pointer matching —
+// always removes exactly the registration it was given. It is a no-op when
+// the handler is already gone (unsubscribed twice, or removed by Clear).
+func (bus *EventBus) removeHandler(eventType reflect.Type, h *internalHandler) {
+	shard := bus.getShard(eventType)
+	shard.mu.Lock()
+	defer shard.mu.Unlock()
+
+	handlers := shard.handlers[eventType]
+	for i, existing := range handlers {
+		if existing == h {
+			shard.handlers[eventType] = append(handlers[:i], handlers[i+1:]...)
+			return
+		}
+	}
+}
+
+// OriginID returns the unique identifier of this bus instance. Every event
+// the bus persists carries it as Event.Origin, so consumers of a log shared
+// by several processes can tell this instance's events from a peer's.
+func (bus *EventBus) OriginID() string {
+	return bus.originID
+}
+
+// Subscription is a handle to a single registration, returned by
+// SubscribeWithHandle and SubscribeContextWithHandle. Unlike Unsubscribe —
+// which matches handlers by function code pointer and therefore cannot tell
+// two closures from the same function literal apart — a handle identifies
+// exactly the registration that created it.
+type Subscription struct {
+	bus       *EventBus
+	eventType reflect.Type
+	h         *internalHandler
+}
+
+// Unsubscribe removes this subscription's handler from the bus. It is
+// idempotent: calling it more than once (or after Clear/ClearAll already
+// removed the handler) is a no-op. Safe for concurrent use.
+func (s *Subscription) Unsubscribe() {
+	s.bus.removeHandler(s.eventType, s.h)
+}
+
+// SubscribeWithHandle registers a handler for events of type T and returns a
+// Subscription handle for precise removal. Semantics are identical to
+// Subscribe otherwise; T must be a concrete type.
+//
+// Prefer this over Subscribe+Unsubscribe when the handler is a closure:
+// handles remove exactly the registration they came from, with none of
+// Unsubscribe's code-pointer ambiguity.
+func SubscribeWithHandle[T any](bus *EventBus, handler Handler[T], opts ...SubscribeOption) (*Subscription, error) {
+	if bus == nil {
+		return nil, fmt.Errorf("eventbus: bus cannot be nil")
+	}
+	if handler == nil {
+		return nil, fmt.Errorf("eventbus: handler cannot be nil")
+	}
+
+	eventType := reflect.TypeOf((*T)(nil)).Elem()
+	h, err := buildHandler(handler, eventType, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	bus.addHandler(eventType, h)
+	return &Subscription{bus: bus, eventType: eventType, h: h}, nil
+}
+
+// SubscribeContextWithHandle registers a context-aware handler for events of
+// type T and returns a Subscription handle for precise removal. Semantics are
+// identical to SubscribeContext otherwise; T must be a concrete type.
+func SubscribeContextWithHandle[T any](bus *EventBus, handler ContextHandler[T], opts ...SubscribeOption) (*Subscription, error) {
+	if bus == nil {
+		return nil, fmt.Errorf("eventbus: bus cannot be nil")
+	}
+	if handler == nil {
+		return nil, fmt.Errorf("eventbus: handler cannot be nil")
+	}
+
+	eventType := reflect.TypeOf((*T)(nil)).Elem()
+	h, err := buildHandler(handler, eventType, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	bus.addHandler(eventType, h)
+	return &Subscription{bus: bus, eventType: eventType, h: h}, nil
 }
 
 // Subscribe registers a handler for events of type T.
@@ -335,8 +435,10 @@ func validateFilter(h *internalHandler, eventType reflect.Type) error {
 //     pointer and are indistinguishable; the first registered one is removed.
 //   - Method values on different receivers share a code pointer.
 //
-// If you need precise unsubscription of closures, keep a reference to the
-// exact handler you registered and unsubscribe with it, or use Clear[T].
+// If you need precise unsubscription of closures, use SubscribeWithHandle
+// and the returned Subscription's Unsubscribe method instead — handles are
+// matched by identity, not code pointer. Alternatively keep a reference to
+// the exact handler you registered and unsubscribe with it, or use Clear[T].
 func Unsubscribe[T any, H any](bus *EventBus, handler H) error {
 	if bus == nil {
 		return fmt.Errorf("eventbus: bus cannot be nil")
@@ -370,10 +472,39 @@ func Publish[T any](bus *EventBus, event T) {
 // It panics if bus is nil.
 //
 // When the bus has a store configured (WithStore), the event is persisted
-// before handlers run. Persistence is best-effort: on failure the event is
-// still delivered to handlers and the error is reported to the
-// PersistenceErrorHandler (see WithPersistenceErrorHandler).
+// before handlers run. Persistence is best-effort by default: on failure the
+// event is still delivered to handlers and the error is reported to the
+// PersistenceErrorHandler (see WithPersistenceErrorHandler). With
+// WithStrictPersistence, a failed persist skips delivery instead. Use
+// TryPublish/TryPublishContext to receive the persistence error directly.
 func PublishContext[T any](bus *EventBus, ctx context.Context, event T) {
+	publishContext(bus, ctx, event)
+}
+
+// TryPublish is Publish with the persistence outcome returned: it reports the
+// error when the bus failed to persist the event (nil on success or when no
+// store is configured). It panics if bus is nil.
+func TryPublish[T any](bus *EventBus, event T) error {
+	return publishContext(bus, context.Background(), event)
+}
+
+// TryPublishContext is PublishContext with the persistence outcome returned.
+//
+// The returned error does not by itself imply handlers were skipped: in
+// best-effort mode (the default) delivery proceeds despite the error, while
+// under WithStrictPersistence delivery is skipped. Either way the error is
+// also reported to the PersistenceErrorHandler, which remains the right
+// channel for passive monitoring; TryPublishContext is for publishers that
+// must act on the failure (e.g. fail the request that caused the publish).
+// It panics if bus is nil.
+func TryPublishContext[T any](bus *EventBus, ctx context.Context, event T) error {
+	return publishContext(bus, ctx, event)
+}
+
+// publishContext is the single publish path: it persists (when configured),
+// delivers, and returns the persistence error, if any. Publish/PublishContext
+// discard the error; TryPublish/TryPublishContext surface it.
+func publishContext[T any](bus *EventBus, ctx context.Context, event T) error {
 	if bus == nil {
 		panic("eventbus: Publish called with nil bus")
 	}
@@ -396,18 +527,28 @@ func PublishContext[T any](bus *EventBus, ctx context.Context, event T) {
 
 	// Persist the event before handlers run. On success the assigned offset
 	// is attached to ctx and can be retrieved with OffsetFromContext.
+	var persistErr error
 	if bus.store != nil {
-		ctx = bus.persistEvent(ctx, eventType, event)
+		ctx, persistErr = bus.persistEvent(ctx, eventType, event)
 	}
+
+	// In strict mode a failed persist skips delivery: handlers never observe
+	// an event the log did not record, so replay and live handling can never
+	// diverge. The after-publish hooks and observability below still fire so
+	// monitoring sees the attempt.
+	deliver := persistErr == nil || !bus.strictPersistence
 
 	// Get handlers from appropriate shard
 	shard := bus.getShard(eventType)
-	shard.mu.RLock()
-	handlers := shard.handlers[eventType]
-	// Create a copy to avoid holding the lock during handler execution
-	handlersCopy := make([]*internalHandler, len(handlers))
-	copy(handlersCopy, handlers)
-	shard.mu.RUnlock()
+	var handlersCopy []*internalHandler
+	if deliver {
+		shard.mu.RLock()
+		handlers := shard.handlers[eventType]
+		// Create a copy to avoid holding the lock during handler execution
+		handlersCopy = make([]*internalHandler, len(handlers))
+		copy(handlersCopy, handlers)
+		shard.mu.RUnlock()
+	}
 
 	// Execute handlers without holding the lock
 	var onceHandlersToRemove []*internalHandler
@@ -503,6 +644,8 @@ func PublishContext[T any](bus *EventBus, ctx context.Context, event T) {
 	if bus.observability != nil {
 		bus.observability.OnPublishComplete(ctx, eventTypeName)
 	}
+
+	return persistErr
 }
 
 // Clear removes all handlers for events of type T
@@ -678,6 +821,22 @@ func WithBeforePublishContext(hook PublishHookContext) Option {
 func WithAfterPublishContext(hook PublishHookContext) Option {
 	return func(bus *EventBus) {
 		bus.afterPublishCtx = hook
+	}
+}
+
+// WithStrictPersistence makes persistence a delivery precondition: when an
+// event cannot be persisted (marshal or Append failure), it is NOT delivered
+// to handlers. Without this option persistence is best-effort — handlers can
+// observe an event the log never recorded, so a later replay would diverge
+// from what live handlers saw. Enable it when the store is the source of
+// truth (event sourcing, cross-process delivery).
+//
+// The failure is still reported to the PersistenceErrorHandler, and
+// TryPublish/TryPublishContext return it to the publisher. It has no effect
+// on a bus without a store.
+func WithStrictPersistence() Option {
+	return func(bus *EventBus) {
+		bus.strictPersistence = true
 	}
 }
 

--- a/hardening_test.go
+++ b/hardening_test.go
@@ -1,0 +1,421 @@
+package eventbus
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// --- ULID event IDs ---
+
+func TestNewEventIDFormat(t *testing.T) {
+	id := NewEventID()
+	if len(id) != 26 {
+		t.Fatalf("expected 26 characters, got %d (%q)", len(id), id)
+	}
+	for i, c := range id {
+		if !strings.ContainsRune(crockford32, c) {
+			t.Errorf("character %d (%q) not in Crockford base32 alphabet", i, c)
+		}
+	}
+	// 128 bits in 130 bits of space: the first character's two high bits are
+	// always zero, so it is at most '7'.
+	if id[0] > '7' {
+		t.Errorf("first character %q exceeds '7'", id[0])
+	}
+}
+
+func TestNewEventIDTimestamp(t *testing.T) {
+	before := time.Now().UnixMilli()
+	id := NewEventID()
+	after := time.Now().UnixMilli()
+
+	// The first 10 characters encode the 48-bit millisecond timestamp.
+	var ms int64
+	for _, c := range id[:10] {
+		ms = ms<<5 | int64(strings.IndexRune(crockford32, c))
+	}
+	if ms < before || ms > after {
+		t.Errorf("decoded timestamp %d outside publish window [%d, %d]", ms, before, after)
+	}
+}
+
+func TestNewEventIDUnique(t *testing.T) {
+	const goroutines = 4
+	const perGoroutine = 2500 // enough to force several entropy buffer refills
+
+	var mu sync.Mutex
+	seen := make(map[string]bool, goroutines*perGoroutine)
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ids := make([]string, perGoroutine)
+			for i := range ids {
+				ids[i] = NewEventID()
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			for _, id := range ids {
+				if seen[id] {
+					t.Errorf("duplicate ID %q", id)
+				}
+				seen[id] = true
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestNewEventIDSortsByTime(t *testing.T) {
+	first := NewEventID()
+	time.Sleep(2 * time.Millisecond)
+	second := NewEventID()
+	if !(first < second) {
+		t.Errorf("expected %q < %q (later IDs must sort after earlier ones)", first, second)
+	}
+}
+
+// --- Event envelope: ID, Origin, Metadata ---
+
+type envelopeEvent struct {
+	Value int
+}
+
+func TestPublishAssignsEnvelope(t *testing.T) {
+	store := NewMemoryStore()
+	bus := New(WithStore(store))
+
+	if bus.OriginID() == "" {
+		t.Fatal("expected bus to have an origin ID")
+	}
+
+	Publish(bus, envelopeEvent{Value: 1})
+
+	events, _, err := store.Read(context.Background(), OffsetOldest, 0)
+	if err != nil || len(events) != 1 {
+		t.Fatalf("expected 1 stored event, got %d (err=%v)", len(events), err)
+	}
+	if len(events[0].ID) != 26 {
+		t.Errorf("expected a 26-char ULID event ID, got %q", events[0].ID)
+	}
+	if events[0].Origin != bus.OriginID() {
+		t.Errorf("expected origin %q, got %q", bus.OriginID(), events[0].Origin)
+	}
+	if events[0].Metadata != nil {
+		t.Errorf("expected no metadata, got %v", events[0].Metadata)
+	}
+}
+
+func TestDistinctBusesHaveDistinctOrigins(t *testing.T) {
+	if New().OriginID() == New().OriginID() {
+		t.Error("two buses share an origin ID")
+	}
+}
+
+func TestContextWithMetadataPersisted(t *testing.T) {
+	store := NewMemoryStore()
+	bus := New(WithStore(store))
+
+	md := map[string]string{"correlation_id": "req-42", "tenant": "acme"}
+	ctx := ContextWithMetadata(context.Background(), md)
+
+	var handlerMD map[string]string
+	var handlerOK bool
+	SubscribeContext(bus, func(hctx context.Context, e envelopeEvent) {
+		handlerMD, handlerOK = MetadataFromContext(hctx)
+	})
+
+	PublishContext(bus, ctx, envelopeEvent{Value: 1})
+
+	events, _, _ := store.Read(context.Background(), OffsetOldest, 0)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 stored event, got %d", len(events))
+	}
+	if events[0].Metadata["correlation_id"] != "req-42" || events[0].Metadata["tenant"] != "acme" {
+		t.Errorf("stored metadata mismatch: %v", events[0].Metadata)
+	}
+	if !handlerOK || handlerMD["correlation_id"] != "req-42" {
+		t.Errorf("handler metadata mismatch: ok=%v md=%v", handlerOK, handlerMD)
+	}
+}
+
+func TestContextWithMetadataEmptyIsNoop(t *testing.T) {
+	ctx := context.Background()
+	if ContextWithMetadata(ctx, nil) != ctx {
+		t.Error("nil metadata should return the context unchanged")
+	}
+	if ContextWithMetadata(ctx, map[string]string{}) != ctx {
+		t.Error("empty metadata should return the context unchanged")
+	}
+	if _, ok := MetadataFromContext(ctx); ok {
+		t.Error("expected no metadata on a bare context")
+	}
+}
+
+func TestEventIDFromContext(t *testing.T) {
+	store := NewMemoryStore()
+	bus := New(WithStore(store))
+
+	var handlerID string
+	var handlerOK bool
+	SubscribeContext(bus, func(hctx context.Context, e envelopeEvent) {
+		handlerID, handlerOK = EventIDFromContext(hctx)
+	})
+
+	Publish(bus, envelopeEvent{Value: 1})
+
+	events, _, _ := store.Read(context.Background(), OffsetOldest, 0)
+	if len(events) != 1 {
+		t.Fatalf("expected 1 stored event, got %d", len(events))
+	}
+	if !handlerOK {
+		t.Fatal("expected handler to see the event ID")
+	}
+	if handlerID != events[0].ID {
+		t.Errorf("handler saw ID %q, store recorded %q", handlerID, events[0].ID)
+	}
+}
+
+func TestEventIDFromContextWithoutStore(t *testing.T) {
+	bus := New()
+	var ok bool
+	SubscribeContext(bus, func(hctx context.Context, e envelopeEvent) {
+		_, ok = EventIDFromContext(hctx)
+	})
+	Publish(bus, envelopeEvent{Value: 1})
+	if ok {
+		t.Error("expected no event ID on a bus without a store")
+	}
+}
+
+func TestEventIDPresentWhenPersistFails(t *testing.T) {
+	// Best-effort mode: the event is delivered despite the Append failure,
+	// and the ID — which identifies the publish, not the storage outcome —
+	// must still be visible to handlers.
+	bus := New(WithStore(&errorStore{failAppend: true}))
+	var id string
+	var ok bool
+	SubscribeContext(bus, func(hctx context.Context, e envelopeEvent) {
+		id, ok = EventIDFromContext(hctx)
+	})
+	Publish(bus, envelopeEvent{Value: 1})
+	if !ok || len(id) != 26 {
+		t.Errorf("expected a ULID despite persist failure, got ok=%v id=%q", ok, id)
+	}
+	if _, offsetOK := OffsetFromContext(context.Background()); offsetOK {
+		t.Error("bare context must not carry an offset")
+	}
+}
+
+// --- Strict persistence and TryPublish ---
+
+func TestStrictPersistenceSkipsDeliveryOnAppendFailure(t *testing.T) {
+	var reported error
+	bus := New(
+		WithStore(&errorStore{failAppend: true}),
+		WithStrictPersistence(),
+		WithPersistenceErrorHandler(func(event any, eventType reflect.Type, err error) {
+			reported = err
+		}),
+	)
+
+	called := false
+	Subscribe(bus, func(e envelopeEvent) { called = true })
+
+	afterHookFired := false
+	bus.SetAfterPublishHook(func(eventType reflect.Type, event any) { afterHookFired = true })
+
+	Publish(bus, envelopeEvent{Value: 1})
+
+	if called {
+		t.Error("handler must not run when strict persistence fails")
+	}
+	if reported == nil {
+		t.Error("expected the failure to reach the PersistenceErrorHandler")
+	}
+	if !afterHookFired {
+		t.Error("after-publish hook should still fire on a strict-mode failure")
+	}
+}
+
+func TestStrictPersistenceDeliversOnSuccess(t *testing.T) {
+	bus := New(WithStore(NewMemoryStore()), WithStrictPersistence())
+	called := false
+	Subscribe(bus, func(e envelopeEvent) { called = true })
+	Publish(bus, envelopeEvent{Value: 1})
+	if !called {
+		t.Error("handler should run when persistence succeeds in strict mode")
+	}
+}
+
+func TestBestEffortDeliversDespiteAppendFailure(t *testing.T) {
+	bus := New(WithStore(&errorStore{failAppend: true}))
+	called := false
+	Subscribe(bus, func(e envelopeEvent) { called = true })
+	Publish(bus, envelopeEvent{Value: 1})
+	if !called {
+		t.Error("best-effort mode must deliver despite the persist failure")
+	}
+}
+
+func TestTryPublishReturnsAppendError(t *testing.T) {
+	bus := New(WithStore(&errorStore{failAppend: true}))
+	if err := TryPublish(bus, envelopeEvent{Value: 1}); err == nil {
+		t.Error("expected TryPublish to return the append error")
+	}
+}
+
+func TestTryPublishContextStrictSkipsDelivery(t *testing.T) {
+	bus := New(WithStore(&errorStore{failAppend: true}), WithStrictPersistence())
+	called := false
+	Subscribe(bus, func(e envelopeEvent) { called = true })
+	err := TryPublishContext(bus, context.Background(), envelopeEvent{Value: 1})
+	if err == nil {
+		t.Error("expected TryPublishContext to return the append error")
+	}
+	if called {
+		t.Error("strict mode must not deliver on persist failure")
+	}
+}
+
+func TestTryPublishNilOnSuccessAndWithoutStore(t *testing.T) {
+	if err := TryPublish(New(), envelopeEvent{Value: 1}); err != nil {
+		t.Errorf("expected nil without a store, got %v", err)
+	}
+	if err := TryPublish(New(WithStore(NewMemoryStore())), envelopeEvent{Value: 1}); err != nil {
+		t.Errorf("expected nil on successful persist, got %v", err)
+	}
+}
+
+type unmarshalableEvent struct {
+	Ch chan int // channels cannot be marshaled to JSON
+}
+
+func TestTryPublishReturnsMarshalErrorAndStrictSkips(t *testing.T) {
+	bus := New(WithStore(NewMemoryStore()), WithStrictPersistence())
+	called := false
+	Subscribe(bus, func(e unmarshalableEvent) { called = true })
+	if err := TryPublish(bus, unmarshalableEvent{Ch: make(chan int)}); err == nil {
+		t.Error("expected a marshal error")
+	}
+	if called {
+		t.Error("strict mode must not deliver an event that could not be marshaled")
+	}
+}
+
+// --- Subscription handles ---
+
+type handleEvent struct {
+	Value int
+}
+
+func TestSubscribeWithHandle(t *testing.T) {
+	bus := New()
+	var got []int
+	sub, err := SubscribeWithHandle(bus, func(e handleEvent) { got = append(got, e.Value) })
+	if err != nil {
+		t.Fatalf("SubscribeWithHandle: %v", err)
+	}
+
+	Publish(bus, handleEvent{Value: 1})
+	sub.Unsubscribe()
+	Publish(bus, handleEvent{Value: 2})
+	sub.Unsubscribe() // idempotent
+
+	if len(got) != 1 || got[0] != 1 {
+		t.Errorf("expected exactly [1], got %v", got)
+	}
+}
+
+func TestSubscribeWithHandleDistinguishesIdenticalClosures(t *testing.T) {
+	// Two closures from the same function literal share a code pointer, so
+	// Unsubscribe cannot tell them apart — handles must.
+	bus := New()
+	counts := make([]int, 2)
+	var subs []*Subscription
+	for i := 0; i < 2; i++ {
+		i := i
+		sub, err := SubscribeWithHandle(bus, func(e handleEvent) { counts[i]++ })
+		if err != nil {
+			t.Fatalf("SubscribeWithHandle: %v", err)
+		}
+		subs = append(subs, sub)
+	}
+
+	// Remove the SECOND registration; code-pointer matching would remove the
+	// first one instead.
+	subs[1].Unsubscribe()
+	Publish(bus, handleEvent{Value: 1})
+
+	if counts[0] != 1 {
+		t.Errorf("first subscription should survive, count=%d", counts[0])
+	}
+	if counts[1] != 0 {
+		t.Errorf("second subscription should be removed, count=%d", counts[1])
+	}
+}
+
+func TestSubscribeContextWithHandle(t *testing.T) {
+	bus := New()
+	called := false
+	sub, err := SubscribeContextWithHandle(bus, func(ctx context.Context, e handleEvent) { called = true })
+	if err != nil {
+		t.Fatalf("SubscribeContextWithHandle: %v", err)
+	}
+	Publish(bus, handleEvent{Value: 1})
+	if !called {
+		t.Error("expected context handler to run")
+	}
+	sub.Unsubscribe()
+	called = false
+	Publish(bus, handleEvent{Value: 2})
+	if called {
+		t.Error("expected handler to be removed")
+	}
+}
+
+func TestSubscribeWithHandleValidation(t *testing.T) {
+	bus := New()
+
+	if _, err := SubscribeWithHandle[handleEvent](nil, func(e handleEvent) {}); err == nil {
+		t.Error("expected error for nil bus")
+	}
+	if _, err := SubscribeWithHandle[handleEvent](bus, nil); err == nil {
+		t.Error("expected error for nil handler")
+	}
+	if _, err := SubscribeWithHandle(bus, func(e handleEvent) {}, nil); err == nil {
+		t.Error("expected error for nil option")
+	}
+	if _, err := SubscribeWithHandle(bus, func(e handleEvent) {},
+		WithFilter(func(other envelopeEvent) bool { return true })); err == nil {
+		t.Error("expected error for mismatched filter type")
+	}
+
+	if _, err := SubscribeContextWithHandle[handleEvent](nil, func(ctx context.Context, e handleEvent) {}); err == nil {
+		t.Error("expected error for nil bus (context variant)")
+	}
+	if _, err := SubscribeContextWithHandle[handleEvent](bus, nil); err == nil {
+		t.Error("expected error for nil handler (context variant)")
+	}
+	if _, err := SubscribeContextWithHandle(bus, func(ctx context.Context, e handleEvent) {}, nil); err == nil {
+		t.Error("expected error for nil option (context variant)")
+	}
+}
+
+func TestUnsubscribeAfterClearIsNoop(t *testing.T) {
+	bus := New()
+	sub, err := SubscribeWithHandle(bus, func(e handleEvent) {})
+	if err != nil {
+		t.Fatalf("SubscribeWithHandle: %v", err)
+	}
+	Clear[handleEvent](bus)
+	sub.Unsubscribe() // must not panic or affect other state
+	if HasHandlers[handleEvent](bus) {
+		t.Error("expected no handlers after Clear")
+	}
+}

--- a/persist.go
+++ b/persist.go
@@ -114,18 +114,45 @@ type EventStoreTruncator interface {
 }
 
 // Event represents an event to be stored (before it has an offset).
+//
+// ID, Origin, and Metadata form the event envelope. All three are optional
+// at the storage level (`omitempty`), so streams written by earlier ebu
+// versions or by external producers decode cleanly with empty values.
 type Event struct {
-	Type      string          `json:"type"`
-	Data      json.RawMessage `json:"data"`
-	Timestamp time.Time       `json:"timestamp"`
+	// ID is a globally unique identifier for the publish that produced this
+	// event (a ULID, see NewEventID). The bus assigns it once, before the
+	// first Append attempt, so a store that retries a failed append writes
+	// the SAME ID for every attempt — consumers can deduplicate at-least-once
+	// deliveries on it.
+	ID string `json:"id,omitempty"`
+
+	// Origin identifies the bus instance that published the event (each
+	// EventBus gets a unique origin at New). On a log shared by several
+	// processes it tells "my own event echoed back" apart from a peer's.
+	Origin string `json:"origin,omitempty"`
+
+	Type string          `json:"type"`
+	Data json.RawMessage `json:"data"`
+
+	// Metadata carries publisher-supplied key/value pairs (correlation IDs,
+	// causation IDs, tenant tags, ...). Attach it to the publish context with
+	// ContextWithMetadata. The bus never reads or writes keys itself.
+	Metadata map[string]string `json:"metadata,omitempty"`
+
+	Timestamp time.Time `json:"timestamp"`
 }
 
 // StoredEvent represents an event that has been persisted with an offset.
+// ID, Origin, and Metadata mirror the Event envelope; they are empty for
+// events written before the envelope existed or by external producers.
 type StoredEvent struct {
-	Offset    Offset          `json:"offset"`
-	Type      string          `json:"type"`
-	Data      json.RawMessage `json:"data"`
-	Timestamp time.Time       `json:"timestamp"`
+	Offset    Offset            `json:"offset"`
+	ID        string            `json:"id,omitempty"`
+	Origin    string            `json:"origin,omitempty"`
+	Type      string            `json:"type"`
+	Data      json.RawMessage   `json:"data"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+	Timestamp time.Time         `json:"timestamp"`
 }
 
 // WithStore enables persistence with the given store.
@@ -152,6 +179,47 @@ func OffsetFromContext(ctx context.Context) (Offset, bool) {
 	return offset, ok
 }
 
+// eventIDCtxKey is the context key under which the ID assigned to the event
+// being published is stored.
+type eventIDCtxKey struct{}
+
+// EventIDFromContext returns the ID assigned to the event currently being
+// handled. It is set for every publish on a bus configured with WithStore —
+// including publishes whose Append failed in best-effort mode, since the ID
+// identifies the publish, not the storage outcome. Context-aware handlers can
+// use it for idempotency keys and correlation.
+func EventIDFromContext(ctx context.Context) (string, bool) {
+	id, ok := ctx.Value(eventIDCtxKey{}).(string)
+	return id, ok
+}
+
+// metadataCtxKey is the context key under which publisher-supplied event
+// metadata travels from PublishContext to persistEvent.
+type metadataCtxKey struct{}
+
+// ContextWithMetadata returns a context that attaches metadata to every event
+// subsequently published with it on a bus configured with WithStore. The map
+// is stored on the persisted event's envelope (Event.Metadata) and surfaces
+// on replay via StoredEvent.Metadata.
+//
+// The map is not copied: callers must not mutate it after publishing.
+// Publishing with a context that already carries metadata replaces the whole
+// map (no merging). A nil or empty map attaches nothing.
+func ContextWithMetadata(ctx context.Context, md map[string]string) context.Context {
+	if len(md) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, metadataCtxKey{}, md)
+}
+
+// MetadataFromContext returns the event metadata attached to ctx with
+// ContextWithMetadata, if any. Inside handlers it returns the metadata of the
+// event being delivered, since the publish context is what handlers receive.
+func MetadataFromContext(ctx context.Context) (map[string]string, bool) {
+	md, ok := ctx.Value(metadataCtxKey{}).(map[string]string)
+	return md, ok
+}
+
 // WithSubscriptionStore enables subscription position tracking
 func WithSubscriptionStore(store SubscriptionStore) Option {
 	return func(bus *EventBus) {
@@ -159,28 +227,42 @@ func WithSubscriptionStore(store SubscriptionStore) Option {
 	}
 }
 
-// persistEvent saves an event to storage and returns a context that carries
-// the assigned offset on success (see OffsetFromContext). On failure it
-// reports to the PersistenceErrorHandler and returns the context unchanged.
+// persistEvent saves an event to storage. It returns a context that carries
+// the event's assigned ID (always) and its offset (on success, see
+// OffsetFromContext), plus the persistence error, if any. Every error is
+// reported to the PersistenceErrorHandler before being returned; the caller
+// decides — based on WithStrictPersistence — whether the error also stops
+// delivery.
 //
 // Concurrency note: the bus does not serialize Append calls; stores must be
 // safe for concurrent use (all bundled stores are).
-func (bus *EventBus) persistEvent(ctx context.Context, eventType reflect.Type, event any) context.Context {
+func (bus *EventBus) persistEvent(ctx context.Context, eventType reflect.Type, event any) (context.Context, error) {
+	// The ID identifies this publish: it is minted before the first Append
+	// attempt so retries inside a store write the same ID, and it is attached
+	// to ctx even when persistence fails (see EventIDFromContext).
+	eventID := NewEventID()
+	ctx = context.WithValue(ctx, eventIDCtxKey{}, eventID)
+
 	// Marshal the event first
 	data, err := json.Marshal(event)
 	if err != nil {
+		err = fmt.Errorf("failed to marshal event: %w", err)
 		if bus.persistenceErrorHandler != nil {
-			bus.persistenceErrorHandler(event, eventType, fmt.Errorf("failed to marshal event: %w", err))
+			bus.persistenceErrorHandler(event, eventType, err)
 		}
-		return ctx
+		return ctx, err
 	}
 
 	// Use EventType() to respect TypeNamer interface if implemented
 	typeName := EventType(event)
 
+	metadata, _ := MetadataFromContext(ctx)
 	toStore := &Event{
+		ID:        eventID,
+		Origin:    bus.originID,
 		Type:      typeName,
 		Data:      data,
+		Metadata:  metadata,
 		Timestamp: time.Now(),
 	}
 
@@ -209,13 +291,14 @@ func (bus *EventBus) persistEvent(ctx context.Context, eventType reflect.Type, e
 	}
 
 	if saveErr != nil {
+		saveErr = fmt.Errorf("failed to save event: %w", saveErr)
 		if bus.persistenceErrorHandler != nil {
-			bus.persistenceErrorHandler(event, eventType, fmt.Errorf("failed to save event: %w", saveErr))
+			bus.persistenceErrorHandler(event, eventType, saveErr)
 		}
-		return ctx
+		return ctx, saveErr
 	}
 
-	return context.WithValue(ctx, offsetCtxKey{}, offset)
+	return context.WithValue(ctx, offsetCtxKey{}, offset), nil
 }
 
 // Replay replays events from an offset
@@ -392,6 +475,13 @@ func WithReplayErrorPolicy(policy ReplayErrorPolicy) SubscribeOption {
 //
 // SaveOffset failures do not stop delivery; they are reported to the
 // PersistenceErrorHandler.
+//
+// Async() caveat: with an async subscription, live-phase offset saves run
+// concurrently and may complete out of publish order, so a slower earlier
+// event can overwrite the stored offset with a smaller value. Delivery
+// remains at-least-once — a crash simply redelivers a little more history on
+// restart — but subscriptions that want to minimize redelivery should stay
+// synchronous (the default) or make handlers idempotent on StoredEvent.ID.
 //
 // Validation: all argument and option validation (nil bus/handler/options,
 // interface event types, filter shape) happens before the replay pass, so a
@@ -591,8 +681,11 @@ func (m *MemoryStore) Append(ctx context.Context, event *Event) (Offset, error) 
 
 	stored := &StoredEvent{
 		Offset:    offset,
+		ID:        event.ID,
+		Origin:    event.Origin,
 		Type:      event.Type,
 		Data:      event.Data,
+		Metadata:  event.Metadata,
 		Timestamp: event.Timestamp,
 	}
 	m.events = append(m.events, stored)

--- a/stores/durablestream/envelope_test.go
+++ b/stores/durablestream/envelope_test.go
@@ -1,0 +1,84 @@
+package durablestream_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	eventbus "github.com/jilio/ebu"
+	ds "github.com/jilio/ebu/stores/durablestream"
+)
+
+// TestEnvelopeRoundTrip verifies that ID, Origin, and Metadata survive
+// Append -> Read through a real durable-streams protocol handler.
+func TestEnvelopeRoundTrip(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	store, err := ds.New(srv.URL+"/v1/stream", "envelope-test")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx := context.Background()
+	want := &eventbus.Event{
+		ID:        "01JTESTID0000000000000000A",
+		Origin:    "origin-1",
+		Type:      "test.event",
+		Data:      json.RawMessage(`{"v":1}`),
+		Metadata:  map[string]string{"correlation_id": "req-1"},
+		Timestamp: time.Now(),
+	}
+	if _, err := store.Append(ctx, want); err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+
+	events, _, err := store.Read(ctx, eventbus.OffsetOldest, 0)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	got := events[0]
+	if got.ID != want.ID {
+		t.Errorf("ID: got %q, want %q", got.ID, want.ID)
+	}
+	if got.Origin != want.Origin {
+		t.Errorf("Origin: got %q, want %q", got.Origin, want.Origin)
+	}
+	if got.Metadata["correlation_id"] != "req-1" {
+		t.Errorf("Metadata: got %v", got.Metadata)
+	}
+}
+
+// TestEnvelopeAbsentFieldsOmitted verifies that events without envelope
+// fields serialize without the keys (wire compatibility with pre-envelope
+// events) and read back empty.
+func TestEnvelopeAbsentFieldsOmitted(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	store, err := ds.New(srv.URL+"/v1/stream", "envelope-empty-test")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx := context.Background()
+	if _, err := store.Append(ctx, &eventbus.Event{
+		Type: "bare.event",
+		Data: json.RawMessage(`{}`),
+	}); err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+
+	events, _, err := store.Read(ctx, eventbus.OffsetOldest, 0)
+	if err != nil || len(events) != 1 {
+		t.Fatalf("Read: %d events, err=%v", len(events), err)
+	}
+	if events[0].ID != "" || events[0].Origin != "" || events[0].Metadata != nil {
+		t.Errorf("expected empty envelope, got ID=%q Origin=%q Metadata=%v",
+			events[0].ID, events[0].Origin, events[0].Metadata)
+	}
+}

--- a/stores/durablestream/store.go
+++ b/stores/durablestream/store.go
@@ -129,10 +129,15 @@ func NewWithContext(ctx context.Context, baseURL string, streamPath string, opts
 }
 
 // storedEventForWrite represents the event format for writing to the stream.
+// The envelope fields (id, origin, metadata) are omitted when empty so
+// streams stay byte-compatible with events written by earlier versions.
 type storedEventForWrite struct {
-	Type      string          `json:"type"`
-	Data      json.RawMessage `json:"data"`
-	Timestamp string          `json:"timestamp,omitempty"`
+	ID        string            `json:"id,omitempty"`
+	Origin    string            `json:"origin,omitempty"`
+	Type      string            `json:"type"`
+	Data      json.RawMessage   `json:"data"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+	Timestamp string            `json:"timestamp,omitempty"`
 }
 
 // Append stores an event and returns its assigned offset.
@@ -162,8 +167,11 @@ type storedEventForWrite struct {
 // concurrent publishers until it resolves.
 func (s *Store) Append(ctx context.Context, event *eventbus.Event) (eventbus.Offset, error) {
 	writeEvent := storedEventForWrite{
-		Type: event.Type,
-		Data: event.Data,
+		ID:       event.ID,
+		Origin:   event.Origin,
+		Type:     event.Type,
+		Data:     event.Data,
+		Metadata: event.Metadata,
 	}
 	if !event.Timestamp.IsZero() {
 		writeEvent.Timestamp = event.Timestamp.Format(time.RFC3339Nano)
@@ -224,10 +232,13 @@ func (s *Store) Append(ctx context.Context, event *eventbus.Event) (eventbus.Off
 
 // storedEventWithOffset is used to parse events that include their own offset.
 type storedEventWithOffset struct {
-	Offset    string          `json:"offset,omitempty"`
-	Type      string          `json:"type"`
-	Data      json.RawMessage `json:"data"`
-	Timestamp string          `json:"timestamp,omitempty"`
+	Offset    string            `json:"offset,omitempty"`
+	ID        string            `json:"id,omitempty"`
+	Origin    string            `json:"origin,omitempty"`
+	Type      string            `json:"type"`
+	Data      json.RawMessage   `json:"data"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+	Timestamp string            `json:"timestamp,omitempty"`
 }
 
 // Read returns events appended strictly after the given offset.
@@ -356,8 +367,11 @@ func (s *Store) Read(ctx context.Context, from eventbus.Offset, limit int) ([]*e
 
 			events = append(events, &eventbus.StoredEvent{
 				Offset:    eventOffset,
+				ID:        eventWithOffset.ID,
+				Origin:    eventWithOffset.Origin,
 				Type:      eventWithOffset.Type,
 				Data:      eventWithOffset.Data,
+				Metadata:  eventWithOffset.Metadata,
 				Timestamp: parseTimestamp(eventWithOffset.Timestamp),
 			})
 		}

--- a/stores/sqlite/envelope_test.go
+++ b/stores/sqlite/envelope_test.go
@@ -1,0 +1,178 @@
+package sqlite
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	eventbus "github.com/jilio/ebu"
+)
+
+// TestEnvelopeRoundTrip verifies that ID, Origin, and Metadata survive
+// Append -> Read and Append -> ReadStream unchanged.
+func TestEnvelopeRoundTrip(t *testing.T) {
+	store, err := New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	want := &eventbus.Event{
+		ID:        "01JTESTID0000000000000000A",
+		Origin:    "origin-1",
+		Type:      "test.event",
+		Data:      json.RawMessage(`{"v":1}`),
+		Metadata:  map[string]string{"correlation_id": "req-1", "tenant": "acme"},
+		Timestamp: time.Now().UTC(),
+	}
+	if _, err := store.Append(ctx, want); err != nil {
+		t.Fatal(err)
+	}
+
+	check := func(t *testing.T, got *eventbus.StoredEvent) {
+		t.Helper()
+		if got.ID != want.ID {
+			t.Errorf("ID: got %q, want %q", got.ID, want.ID)
+		}
+		if got.Origin != want.Origin {
+			t.Errorf("Origin: got %q, want %q", got.Origin, want.Origin)
+		}
+		if got.Metadata["correlation_id"] != "req-1" || got.Metadata["tenant"] != "acme" {
+			t.Errorf("Metadata: got %v", got.Metadata)
+		}
+	}
+
+	events, _, err := store.Read(ctx, eventbus.OffsetOldest, 0)
+	if err != nil || len(events) != 1 {
+		t.Fatalf("Read: %d events, err=%v", len(events), err)
+	}
+	check(t, events[0])
+
+	var streamed *eventbus.StoredEvent
+	for event, err := range store.ReadStream(ctx, eventbus.OffsetOldest) {
+		if err != nil {
+			t.Fatal(err)
+		}
+		streamed = event
+	}
+	if streamed == nil {
+		t.Fatal("ReadStream yielded nothing")
+	}
+	check(t, streamed)
+}
+
+// TestEnvelopeEmptyFieldsStoredAsNull verifies that events published without
+// an envelope (or through an older core) read back with empty fields, and
+// that the columns are actually NULL rather than empty strings.
+func TestEnvelopeEmptyFieldsStoredAsNull(t *testing.T) {
+	store, err := New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	if _, err := store.Append(ctx, &eventbus.Event{
+		Type: "bare.event", Data: json.RawMessage(`{}`), Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	events, _, err := store.Read(ctx, eventbus.OffsetOldest, 0)
+	if err != nil || len(events) != 1 {
+		t.Fatalf("Read: %d events, err=%v", len(events), err)
+	}
+	if events[0].ID != "" || events[0].Origin != "" || events[0].Metadata != nil {
+		t.Errorf("expected empty envelope, got ID=%q Origin=%q Metadata=%v",
+			events[0].ID, events[0].Origin, events[0].Metadata)
+	}
+
+	var nulls int
+	if err := store.GetDB().QueryRow(
+		"SELECT COUNT(*) FROM events WHERE event_id IS NULL AND origin IS NULL AND metadata IS NULL",
+	).Scan(&nulls); err != nil {
+		t.Fatal(err)
+	}
+	if nulls != 1 {
+		t.Errorf("expected envelope columns to be NULL, got %d matching rows", nulls)
+	}
+}
+
+// TestEnvelopeLegacyRowsReadBack verifies rows written before schema v4
+// (envelope columns absent entirely) read back with empty envelope fields
+// after the migration adds the columns.
+func TestEnvelopeLegacyRowsReadBack(t *testing.T) {
+	store, err := New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	// Simulate a legacy row: write only the pre-v4 columns.
+	if _, err := store.GetDB().Exec(
+		"INSERT INTO events (type, data, timestamp) VALUES ('legacy.event', x'7b7d', CURRENT_TIMESTAMP)",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	events, _, err := store.Read(ctx, eventbus.OffsetOldest, 0)
+	if err != nil || len(events) != 1 {
+		t.Fatalf("Read: %d events, err=%v", len(events), err)
+	}
+	if events[0].Type != "legacy.event" {
+		t.Errorf("Type: got %q", events[0].Type)
+	}
+	if events[0].ID != "" || events[0].Origin != "" || events[0].Metadata != nil {
+		t.Errorf("legacy row must have an empty envelope, got ID=%q Origin=%q Metadata=%v",
+			events[0].ID, events[0].Origin, events[0].Metadata)
+	}
+}
+
+// TestEnvelopeCorruptMetadataErrors verifies that unreadable metadata JSON
+// surfaces as a scan error instead of being silently dropped.
+func TestEnvelopeCorruptMetadataErrors(t *testing.T) {
+	store, err := New(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	if _, err := store.GetDB().Exec(
+		"INSERT INTO events (type, data, timestamp, metadata) VALUES ('t', x'7b7d', CURRENT_TIMESTAMP, 'not-json')",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := store.Read(ctx, eventbus.OffsetOldest, 0); err == nil {
+		t.Error("expected an error for corrupt metadata JSON")
+	}
+}
+
+// TestAppendUnmarshalableMetadata exercises the marshal-failure guard in
+// Append. Metadata is map[string]string, which cannot itself fail to
+// marshal, so this documents the guard via the exported test hook instead.
+func TestMarshalMetadataEmpty(t *testing.T) {
+	v, err := marshalMetadata(nil)
+	if err != nil || v != nil {
+		t.Errorf("nil metadata must marshal to NULL, got %v err=%v", v, err)
+	}
+	v, err = marshalMetadata(map[string]string{})
+	if err != nil || v != nil {
+		t.Errorf("empty metadata must marshal to NULL, got %v err=%v", v, err)
+	}
+	v, err = marshalMetadata(map[string]string{"k": "v"})
+	if err != nil || v != `{"k":"v"}` {
+		t.Errorf("metadata must marshal to a JSON object, got %v err=%v", v, err)
+	}
+
+	if nullifyEmpty("") != nil {
+		t.Error("empty string must map to NULL")
+	}
+	if nullifyEmpty("x") != "x" {
+		t.Error("non-empty string must pass through")
+	}
+}

--- a/stores/sqlite/export_test.go
+++ b/stores/sqlite/export_test.go
@@ -27,6 +27,11 @@ func RunMigrateV3(ctx context.Context, db *sql.DB) error {
 	return migrateV3(ctx, db)
 }
 
+// RunMigrateV4 runs v4 migration on a database (exported for testing)
+func RunMigrateV4(ctx context.Context, db *sql.DB) error {
+	return migrateV4(ctx, db)
+}
+
 // SetStreamBatchSize overrides the stream batch size (exported for testing).
 // A value <= 0 forces the unbatched, point-in-time snapshot stream path.
 func (s *SQLiteStore) SetStreamBatchSize(size int) {

--- a/stores/sqlite/schema.go
+++ b/stores/sqlite/schema.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 )
 
 // Schema version for migrations
-const currentSchemaVersion = 3
+const currentSchemaVersion = 4
 
 // Schema definitions
 const (
@@ -49,6 +50,14 @@ const (
 	// this store ever filters by type, so the index was pure write
 	// amplification on every Append.
 	dropEventsTypeIndex = `DROP INDEX IF EXISTS idx_events_type`
+
+	// Schema v4 adds the event envelope (see eventbus.Event): a globally
+	// unique event ID, the publishing bus's origin, and publisher-supplied
+	// metadata (stored as a JSON object). All three are nullable so rows
+	// written by earlier versions read back as empty envelope fields.
+	addEventIDColumn  = `ALTER TABLE events ADD COLUMN event_id TEXT`
+	addOriginColumn   = `ALTER TABLE events ADD COLUMN origin TEXT`
+	addMetadataColumn = `ALTER TABLE events ADD COLUMN metadata TEXT`
 )
 
 // migrate applies database migrations if needed
@@ -82,7 +91,12 @@ func migrate(ctx context.Context, db *sql.DB) error {
 		}
 	}
 	if version < 3 {
-		return migrateV3(ctx, db)
+		if err := migrateV3(ctx, db); err != nil {
+			return err
+		}
+	}
+	if version < 4 {
+		return migrateV4(ctx, db)
 	}
 
 	return nil
@@ -170,4 +184,47 @@ func migrateV3(ctx context.Context, db *sql.DB) (err error) {
 	}
 
 	return tx.Commit()
+}
+
+// migrateV4 adds the event envelope columns (see addEventIDColumn).
+//
+// ALTER TABLE ADD COLUMN has no IF NOT EXISTS, so — unlike the earlier,
+// naturally idempotent migrations — a duplicate-column error must be treated
+// as success: two processes racing through migrate() (both reading the same
+// stale version) may both attempt the ALTERs, and the loser would otherwise
+// fail on a column the winner already added.
+func migrateV4(ctx context.Context, db *sql.DB) (err error) {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+
+	defer func() {
+		if err != nil {
+			tx.Rollback()
+		}
+	}()
+
+	for _, stmt := range []string{addEventIDColumn, addOriginColumn, addMetadataColumn} {
+		if _, err = tx.ExecContext(ctx, stmt); err != nil {
+			if isDuplicateColumn(err) {
+				err = nil
+				continue
+			}
+			return fmt.Errorf("exec schema: %w", err)
+		}
+	}
+
+	if _, err = tx.ExecContext(ctx, "INSERT OR IGNORE INTO schema_version (version) VALUES (4)"); err != nil {
+		return fmt.Errorf("exec schema: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+// isDuplicateColumn reports whether err is SQLite's "duplicate column name"
+// error from ALTER TABLE ADD COLUMN. SQLite reports it as a plain
+// SQLITE_ERROR, so the message is the only discriminator.
+func isDuplicateColumn(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "duplicate column name")
 }

--- a/stores/sqlite/snapshot_test.go
+++ b/stores/sqlite/snapshot_test.go
@@ -296,8 +296,8 @@ func TestMigrateAutoOnNewStore(t *testing.T) {
 	if err := store.GetDB().QueryRow("SELECT MAX(version) FROM schema_version").Scan(&version); err != nil {
 		t.Fatal(err)
 	}
-	if version != 3 {
-		t.Errorf("fresh store must be at schema version 3, got %d", version)
+	if version != 4 {
+		t.Errorf("fresh store must be at schema version 4, got %d", version)
 	}
 	// snapshots table is usable end to end.
 	if err := store.SaveSnapshot(context.Background(), "k", "1", json.RawMessage(`{}`)); err != nil {
@@ -308,15 +308,20 @@ func TestMigrateAutoOnNewStore(t *testing.T) {
 func TestMigrateV1ToCurrentUpgrade(t *testing.T) {
 	ctx := context.Background()
 	db := openRawDB(t)
-	// Simulate a v1 database: schema_version present at version 1, no snapshots.
-	if _, err := db.Exec("CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at DATETIME DEFAULT CURRENT_TIMESTAMP)"); err != nil {
-		t.Fatal(err)
+	// Simulate a v1 database: the v1 tables exist, schema_version says 1,
+	// no snapshots table and no envelope columns yet.
+	v1Statements := []string{
+		"CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at DATETIME DEFAULT CURRENT_TIMESTAMP)",
+		"CREATE TABLE events (position INTEGER PRIMARY KEY AUTOINCREMENT, type TEXT NOT NULL, data BLOB NOT NULL, timestamp DATETIME NOT NULL)",
+		"INSERT INTO schema_version (version) VALUES (1)",
 	}
-	if _, err := db.Exec("INSERT INTO schema_version (version) VALUES (1)"); err != nil {
-		t.Fatal(err)
+	for _, stmt := range v1Statements {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatal(err)
+		}
 	}
-	// RunMigrate sees version 1 and must skip v1, applying v2 (add snapshots)
-	// then v3 (drop the type index), ending at 3.
+	// RunMigrate sees version 1 and must skip v1, applying v2 (add snapshots),
+	// v3 (drop the type index) and v4 (envelope columns), ending at 4.
 	if err := sqlite.RunMigrate(ctx, db); err != nil {
 		t.Fatal(err)
 	}
@@ -324,11 +329,14 @@ func TestMigrateV1ToCurrentUpgrade(t *testing.T) {
 	if err := db.QueryRow("SELECT MAX(version) FROM schema_version").Scan(&version); err != nil {
 		t.Fatal(err)
 	}
-	if version != 3 {
-		t.Errorf("v1 upgrade must reach 3, got %d", version)
+	if version != 4 {
+		t.Errorf("v1 upgrade must reach 4, got %d", version)
 	}
 	if _, err := db.Exec("INSERT INTO snapshots (snapshot_id, position, data) VALUES ('k', 1, x'00')"); err != nil {
 		t.Errorf("snapshots table missing after upgrade: %v", err)
+	}
+	if _, err := db.Exec("INSERT INTO events (type, data, timestamp, event_id, origin, metadata) VALUES ('t', x'00', CURRENT_TIMESTAMP, 'id', 'o', '{}')"); err != nil {
+		t.Errorf("envelope columns missing after upgrade: %v", err)
 	}
 }
 
@@ -345,8 +353,8 @@ func TestMigrateRunTwiceIdempotent(t *testing.T) {
 	if err := db.QueryRow("SELECT COUNT(*) FROM schema_version").Scan(&count); err != nil {
 		t.Fatal(err)
 	}
-	if count != 3 { // exactly rows for v1, v2 and v3, no duplicates
-		t.Errorf("idempotent migrate must leave 3 version rows, got %d", count)
+	if count != 4 { // exactly rows for v1..v4, no duplicates
+		t.Errorf("idempotent migrate must leave 4 version rows, got %d", count)
 	}
 }
 

--- a/stores/sqlite/store.go
+++ b/stores/sqlite/store.go
@@ -202,9 +202,9 @@ func (s *SQLiteStore) prepareStatements() error {
 	}
 
 	stmts := []stmtDef{
-		{&s.appendStmt, "INSERT INTO events (type, data, timestamp) VALUES (?, ?, ?)"},
-		{&s.readStmt, "SELECT position, type, data, timestamp FROM events WHERE position > ? ORDER BY position LIMIT ?"},
-		{&s.readFromStmt, "SELECT position, type, data, timestamp FROM events WHERE position > ? ORDER BY position"},
+		{&s.appendStmt, "INSERT INTO events (type, data, timestamp, event_id, origin, metadata) VALUES (?, ?, ?, ?, ?, ?)"},
+		{&s.readStmt, "SELECT position, type, data, timestamp, event_id, origin, metadata FROM events WHERE position > ? ORDER BY position LIMIT ?"},
+		{&s.readFromStmt, "SELECT position, type, data, timestamp, event_id, origin, metadata FROM events WHERE position > ? ORDER BY position"},
 		{&s.saveOffsetStmt, `INSERT INTO subscription_positions (subscription_id, position, updated_at)
 			VALUES (?, ?, CURRENT_TIMESTAMP)
 			ON CONFLICT(subscription_id) DO UPDATE SET position = excluded.position, updated_at = CURRENT_TIMESTAMP`},
@@ -259,7 +259,18 @@ func formatOffset(position int64) eventbus.Offset {
 func (s *SQLiteStore) Append(ctx context.Context, event *eventbus.Event) (eventbus.Offset, error) {
 	start := time.Now()
 
-	result, err := s.appendStmt.ExecContext(ctx, event.Type, event.Data, event.Timestamp)
+	// Envelope fields are stored as NULL when absent so rows written through
+	// old and new cores are indistinguishable on read (both scan as empty).
+	metadataJSON, err := marshalMetadata(event.Metadata)
+	if err != nil {
+		if s.metricsHook != nil {
+			s.metricsHook.OnAppend(time.Since(start), err)
+		}
+		return "", fmt.Errorf("sqlite: marshal event metadata: %w", err)
+	}
+
+	result, err := s.appendStmt.ExecContext(ctx, event.Type, event.Data, event.Timestamp,
+		nullifyEmpty(event.ID), nullifyEmpty(event.Origin), metadataJSON)
 	if err != nil {
 		if s.metricsHook != nil {
 			s.metricsHook.OnAppend(time.Since(start), err)
@@ -351,18 +362,59 @@ func (s *SQLiteStore) Read(ctx context.Context, from eventbus.Offset, limit int)
 	return events, nextOffset, nil
 }
 
+// nullifyEmpty maps an empty string to NULL so envelope fields absent at
+// publish time do not store empty-string values.
+func nullifyEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+// marshalMetadata encodes non-empty metadata as a JSON object, or NULL.
+func marshalMetadata(md map[string]string) (any, error) {
+	if len(md) == 0 {
+		return nil, nil
+	}
+	data, err := json.Marshal(md)
+	if err != nil {
+		return nil, err
+	}
+	return string(data), nil
+}
+
+// scanEvent scans one events row (position, type, data, timestamp, envelope)
+// into a StoredEvent, returning the raw position alongside. Envelope columns
+// are NULL for rows written before schema v4 or through an older core; they
+// scan as empty values.
+func scanEvent(rows rowScanner) (*eventbus.StoredEvent, int64, error) {
+	var position int64
+	var eventID, origin, metadata sql.NullString
+	event := &eventbus.StoredEvent{}
+	if err := rows.Scan(&position, &event.Type, &event.Data, &event.Timestamp, &eventID, &origin, &metadata); err != nil {
+		return nil, 0, fmt.Errorf("sqlite: scan event: %w", err)
+	}
+	event.Offset = formatOffset(position)
+	event.ID = eventID.String
+	event.Origin = origin.String
+	if metadata.Valid && metadata.String != "" {
+		if err := json.Unmarshal([]byte(metadata.String), &event.Metadata); err != nil {
+			return nil, 0, fmt.Errorf("sqlite: unmarshal event metadata at offset %s: %w", event.Offset, err)
+		}
+	}
+	return event, position, nil
+}
+
 // scanEvents scans rows into events - extracted for testability
 func (s *SQLiteStore) scanEvents(rows rowScanner) ([]*eventbus.StoredEvent, error) {
 	defer rows.Close()
 
 	var events []*eventbus.StoredEvent
 	for rows.Next() {
-		var position int64
-		event := &eventbus.StoredEvent{}
-		if err := rows.Scan(&position, &event.Type, &event.Data, &event.Timestamp); err != nil {
-			return nil, fmt.Errorf("sqlite: scan event: %w", err)
+		event, _, err := scanEvent(rows)
+		if err != nil {
+			return nil, err
 		}
-		event.Offset = formatOffset(position)
 		events = append(events, event)
 	}
 
@@ -599,14 +651,12 @@ func (s *SQLiteStore) streamRows(
 		default:
 		}
 
-		var position int64
-		event := &eventbus.StoredEvent{}
-		if err := rows.Scan(&position, &event.Type, &event.Data, &event.Timestamp); err != nil {
-			*iterErr = fmt.Errorf("sqlite: scan event: %w", err)
+		event, _, err := scanEvent(rows)
+		if err != nil {
+			*iterErr = err
 			yield(nil, *iterErr)
 			return
 		}
-		event.Offset = formatOffset(position)
 
 		*eventCount++
 		if !yield(event, nil) {
@@ -688,15 +738,13 @@ func (s *SQLiteStore) streamBatch(
 		default:
 		}
 
-		var position int64
-		event := &eventbus.StoredEvent{}
-		if err := rows.Scan(&position, &event.Type, &event.Data, &event.Timestamp); err != nil {
+		event, position, err := scanEvent(rows)
+		if err != nil {
 			rows.Close() // Best effort close, scan error takes precedence
-			*iterErr = fmt.Errorf("sqlite: scan event: %w", err)
+			*iterErr = err
 			yield(nil, *iterErr)
 			return 0, 0, false
 		}
-		event.Offset = formatOffset(position)
 
 		lastPos = position
 		batchCount++

--- a/stores/sqlite/store_test.go
+++ b/stores/sqlite/store_test.go
@@ -310,8 +310,13 @@ func (m *mockRows) Scan(dest ...any) error {
 	if m.scanErr != nil {
 		return m.scanErr
 	}
+	// Rows may carry fewer columns than dest asks for (legacy 4-column rows
+	// predating the envelope); the missing trailing columns scan as NULL.
 	row := m.data[m.index-1]
 	for i, d := range dest {
+		if i >= len(row) {
+			break
+		}
 		switch ptr := d.(type) {
 		case *int64:
 			*ptr = row[i].(int64)
@@ -321,6 +326,12 @@ func (m *mockRows) Scan(dest ...any) error {
 			*ptr = row[i].([]byte)
 		case *time.Time:
 			*ptr = row[i].(time.Time)
+		case *sql.NullString:
+			if s, ok := row[i].(string); ok {
+				*ptr = sql.NullString{String: s, Valid: true}
+			} else {
+				*ptr = sql.NullString{}
+			}
 		}
 	}
 	return nil
@@ -1136,6 +1147,12 @@ func TestMigrationsVersionInsertIdempotent(t *testing.T) {
 		}
 		if err := RunMigrateV3(ctx, db); err != nil {
 			t.Fatalf("v3 run %d: %v", run, err)
+		}
+		// The second v4 run also exercises duplicate-column tolerance: ALTER
+		// TABLE ADD COLUMN has no IF NOT EXISTS, so re-running must succeed
+		// by treating "duplicate column name" as already-applied.
+		if err := RunMigrateV4(ctx, db); err != nil {
+			t.Fatalf("v4 run %d: %v", run, err)
 		}
 	}
 

--- a/ulid.go
+++ b/ulid.go
@@ -1,0 +1,71 @@
+package eventbus
+
+import (
+	"crypto/rand"
+	"sync"
+	"time"
+)
+
+// crockford32 is the Crockford base32 alphabet used by ULIDs: no I, L, O, U,
+// so identifiers are unambiguous when read or transcribed.
+const crockford32 = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+// ulidEntropy buffers crypto/rand reads. Reading 10 bytes per ID directly
+// from crypto/rand costs a syscall each time; a buffered reader amortizes it
+// across ~100 IDs while keeping the same entropy source.
+var ulidEntropy = struct {
+	sync.Mutex
+	buf []byte
+	pos int
+}{buf: make([]byte, 1024), pos: 1024}
+
+// NewEventID returns a new ULID: a 26-character, lexicographically sortable,
+// globally unique identifier (48-bit millisecond timestamp + 80 bits of
+// crypto/rand entropy, Crockford base32).
+//
+// The bus assigns one to every event it persists (see Event.ID). It is
+// exported so custom stores and tests can mint compatible IDs.
+//
+// IDs sort by creation time to millisecond precision; ties are ordered
+// randomly. Uniqueness does not depend on the clock: the 80 random bits alone
+// make collisions vanishingly unlikely even at the same millisecond.
+func NewEventID() string {
+	var bin [16]byte // 6 timestamp bytes + 10 entropy bytes
+
+	ms := uint64(time.Now().UnixMilli())
+	bin[0] = byte(ms >> 40)
+	bin[1] = byte(ms >> 32)
+	bin[2] = byte(ms >> 24)
+	bin[3] = byte(ms >> 16)
+	bin[4] = byte(ms >> 8)
+	bin[5] = byte(ms)
+
+	ulidEntropy.Lock()
+	if ulidEntropy.pos+10 > len(ulidEntropy.buf) {
+		// crypto/rand.Read never fails on supported platforms (it panics
+		// internally on the truly unrecoverable ones), so the error is
+		// impossible to surface meaningfully here.
+		rand.Read(ulidEntropy.buf)
+		ulidEntropy.pos = 0
+	}
+	copy(bin[6:], ulidEntropy.buf[ulidEntropy.pos:ulidEntropy.pos+10])
+	ulidEntropy.pos += 10
+	ulidEntropy.Unlock()
+
+	// 128 bits -> 26 base32 characters (the top bit pair of the first
+	// character is always zero: 26*5 = 130 bits of space for 128 bits).
+	var out [26]byte
+	out[0] = crockford32[bin[0]>>5]
+	bitPos := 3 // bits already consumed from bin
+	for i := 1; i < 26; i++ {
+		byteIdx := bitPos / 8
+		shift := bitPos % 8
+		v := bin[byteIdx] << shift >> 3
+		if shift > 3 && byteIdx+1 < len(bin) {
+			v |= bin[byteIdx+1] >> (11 - shift)
+		}
+		out[i] = crockford32[v&0x1f]
+		bitPos += 5
+	}
+	return string(out[:])
+}


### PR DESCRIPTION
Addresses the reliability caveats from the library review.

## What's in here

### Event envelope (`ID`, `Origin`, `Metadata`)
Every persisted event now carries:
- **`ID`** — a ULID minted once per publish, *before* the first `Append` attempt, so store-level retries write the same ID. This gives consumers a generic idempotency/dedup key for the at-least-once paths (replay handoff, durablestream retries, chunk-start offsets). Exposed to live handlers via `EventIDFromContext(ctx)`; `NewEventID()` (dependency-free ULID) is exported.
- **`Origin`** — the publishing bus instance's unique ID (`bus.OriginID()`), so consumers of a shared log can tell their own events from a peer's (groundwork for cross-process delivery, PR 2).
- **`Metadata`** — publisher-supplied key/values (correlation/causation IDs), attached with `ContextWithMetadata(ctx, md)`, readable via `StoredEvent.Metadata` or `MetadataFromContext(ctx)`.

All three are optional on the wire (`omitempty` / nullable columns) — existing streams and external producers read back with empty envelope fields.

### Strict persistence
`WithStrictPersistence()` makes persistence a delivery precondition: a failed marshal/`Append` skips handler delivery, so handlers never observe an event the log did not record and replay can never diverge from live handling. Best-effort stays the default.

### Error-returning publish
`TryPublish` / `TryPublishContext` return the persistence error (nil on success or without a store), so a publisher can fail the request that caused the publish. `Publish`/`PublishContext` are unchanged.

### Subscription handles
`SubscribeWithHandle` / `SubscribeContextWithHandle` return a `*Subscription` whose `Unsubscribe()` removes exactly that registration by identity — closing the `Unsubscribe` footgun where two closures from the same function literal share a code pointer. Idempotent, concurrent-safe.

### Stores
- **sqlite**: schema v4 adds nullable `event_id`/`origin`/`metadata` columns. `ALTER TABLE ADD COLUMN` has no `IF NOT EXISTS`, so the migration treats duplicate-column errors as already-applied — keeping the existing "two processes racing through migrate()" guarantee. Legacy rows read back with empty envelopes (tested).
- **durablestream**: envelope fields as optional JSON keys, byte-compatible with pre-envelope streams (round-trip tested against the real protocol handler).

### Docs
`Async()` + `SubscribeWithReplay` out-of-order offset saves documented (at-least-once holds; extra redelivery possible after a crash).

## Verification
- `go test -race ./...` green in all five modules (root, state, sqlite, durablestream, otel)
- Core module coverage remains **100.0%** (per-function verified)
- `go fmt` / `go vet` clean everywhere

## CI note
The `stores/sqlite` and `stores/durablestream` matrix legs run with `GOWORK=off` against the *released* core (v0.15.0), which predates the envelope fields — those two legs will stay red until the next core tag exists (the usual flow: merge → tag core → `go mod tidy` in sub-modules → tag sub-modules). Root and otel legs are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)