### PR TITLE
Cross-process delivery: Follow, WithLogDelivery, EventStoreTailer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Cross-process delivery: `Follow`.** A follower tails the bus's event
+  store and dispatches new events to local subscribers with full option
+  semantics (filters, `Once`, `Async`, `Sequential`, panic recovery, context
+  values). Every process appends by publishing and receives by following —
+  the shared log becomes the bus. Events this bus itself published are
+  skipped by `Origin` (override with `FollowIncludeOwn`); at-least-once
+  duplicates are dropped by event ID (`FollowDedupWindow`, default 1024);
+  `FollowWithSubscriptionID` makes the follower durable across restarts;
+  read errors retry and poison events are reported and skipped, so the
+  follower never wedges. See docs/DISTRIBUTED.md.
+- **`WithLogDelivery`.** Makes the store the only delivery path: `Publish`
+  appends and returns, and all delivery — including in the publishing
+  process — happens through `Follow`. Every process then observes the same
+  events in the same order, and an event that failed to persist is never
+  observed anywhere. Requires `WithStore` (New panics otherwise).
+- **`EventStoreTailer`.** Optional store capability for push-based tailing;
+  `Follow` uses it when available and falls back to polling `Read`
+  otherwise.
+- **durablestream: `Tail`** implements `EventStoreTailer` over the
+  protocol's live long-poll/SSE modes, so followers receive new events
+  within one round trip. Transient failures (including client-side timeouts
+  of idle long-polls) retry forever with capped backoff; permanent protocol
+  errors end the tail.
+
 - **Event envelope: `ID`, `Origin`, `Metadata`.** Every persisted event now
   carries a ULID `ID` minted once per publish (store-level retries reuse it,
   so it is a reliable deduplication key for at-least-once delivery), the

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A lightweight, type-safe event bus for Go with generics support. Build decoupled
 - 🛡️ **Panic recovery** - Handlers are isolated from each other's panics
 - 🚀 **Zero dependencies** - Pure Go standard library (core package)
 - 💾 **Event persistence** - Built-in support for event storage and replay
+- 🔗 **Cross-process delivery** - `Follow` a shared store to span processes and machines
 - 🌍 **Remote storage** - Native support for remote backends like [durable-streams](https://github.com/durable-streams/durable-streams)
 - 🔄 **Event upcasting** - Seamless event schema migration and versioning
 - ✅ **100% test coverage** - Thoroughly tested for reliability
@@ -300,6 +301,39 @@ Available storage backends:
 
 See [**Persistence Guide**](docs/PERSISTENCE.md) for all storage options.
 
+### Scaling Beyond a Single Process
+
+A shared store plus a `Follow` loop turns ebu into a cross-process bus:
+every process appends to the shared log by publishing, and receives by
+following.
+
+```go
+// Both processes: same store.
+store, _ := durablestream.New("http://streams:4437/v1/stream", "orders")
+bus := eventbus.New(eventbus.WithStore(store))
+
+eventbus.Subscribe(bus, func(e OrderCreated) { /* ... */ }) // subscribe first
+go bus.Follow(ctx)                                          // then follow
+
+eventbus.Publish(bus, OrderCreated{ID: "o-1"}) // peers receive it too
+```
+
+- The follower skips events this bus itself published (envelope `Origin`),
+  so nothing arrives twice; other processes' events are dispatched to local
+  handlers with full option semantics (filters, `Once`, `Async`, ...).
+- Stores implementing `EventStoreTailer` (durable-streams) push events via
+  live long-poll/SSE; others are polled (`FollowPollInterval`).
+- `FollowWithSubscriptionID("name")` makes the follower durable: it resumes
+  from its saved offset after a restart.
+- Duplicates from the log's at-least-once layers are dropped by event ID
+  (`FollowDedupWindow`).
+- `eventbus.New(eventbus.WithStore(store), eventbus.WithLogDelivery())`
+  makes the log the *only* delivery path: every process — including the
+  publisher — observes the same events in the same order.
+
+See [**Distributed Guide**](docs/DISTRIBUTED.md) for delivery modes,
+failure behavior, and current limitations.
+
 ### Observability
 
 Add metrics and distributed tracing with OpenTelemetry:
@@ -428,6 +462,7 @@ See [TypeNamer examples](docs/EXAMPLES.md#custom-event-type-names-typenamer) for
 
 - 📖 [**Complete Examples**](docs/EXAMPLES.md) - Comprehensive usage examples
 - 💾 [**Persistence Guide**](docs/PERSISTENCE.md) - Event storage and replay patterns
+- 🔗 [**Distributed Guide**](docs/DISTRIBUTED.md) - Cross-process delivery with Follow
 - 📚 [**API Reference**](https://godoc.org/github.com/jilio/ebu) - Complete API documentation
 
 ## Storage Backends

--- a/docs/DISTRIBUTED.md
+++ b/docs/DISTRIBUTED.md
@@ -1,0 +1,130 @@
+# Distributed ebu: scaling beyond a single process
+
+ebu's core is an in-process bus. Add a shared `EventStore` and a `Follow`
+loop, and it becomes a cross-process one: **every process appends to the
+shared log by publishing, and receives by following.**
+
+```
+process A                    shared log                    process B
+─────────                 (sqlite / durable-streams / …)   ─────────
+Publish ──append──▶  ┌────┬────┬────┬────┬────┐
+                     │ e1 │ e2 │ e3 │ e4 │ e5 │ ◀──append── Publish
+handlers ◀──Follow── └────┴────┴────┴────┴────┘ ──Follow──▶ handlers
+```
+
+## Quick start
+
+```go
+// Both processes: same store, same setup.
+store, _ := durablestream.New("http://streams:4437/v1/stream", "orders")
+bus := eventbus.New(eventbus.WithStore(store))
+
+// Subscribe BEFORE following: only subscribed types can be decoded.
+eventbus.Subscribe(bus, func(e OrderCreated) { ... })
+
+// Tail the log; new events from any process are dispatched locally.
+go func() {
+    if err := bus.Follow(ctx); err != nil && !errors.Is(err, context.Canceled) {
+        log.Printf("follower stopped: %v", err)
+    }
+}()
+
+// Publish as usual — peers receive it via their followers.
+eventbus.Publish(bus, OrderCreated{ID: "o-1"})
+```
+
+`Follow` blocks until its context is cancelled, so run it on a goroutine.
+When the store implements `EventStoreTailer` (durable-streams does — it uses
+the protocol's live long-poll/SSE modes), events are pushed within one round
+trip; otherwise `Follow` polls `Read` on `FollowPollInterval` (default 200ms).
+
+## Delivery modes
+
+### Default: local-first + follower
+
+`Publish` persists and dispatches to local handlers immediately, exactly as
+before. The follower delivers *other* processes' events and skips this bus's
+own (matched by the envelope's `Origin`), so nothing arrives twice. This mode
+adds cross-process delivery without changing local latency or semantics.
+
+### `WithLogDelivery`: the log is the only delivery path
+
+```go
+bus := eventbus.New(
+    eventbus.WithStore(store),
+    eventbus.WithLogDelivery(), // requires WithStore; New panics without it
+)
+```
+
+`Publish` appends and returns; **all** delivery — including to the publishing
+process — happens through `Follow`. Consequences:
+
+- Every process observes **the same events in the same order** (the log's
+  order), which makes cross-process state machines and projections sane.
+- An event that failed to persist is never observed anywhere (strict
+  persistence by construction).
+- Local delivery latency becomes the follower's latency; the process MUST
+  run `bus.Follow` or nothing is ever handled.
+
+## Durable followers
+
+```go
+err := bus.Follow(ctx,
+    eventbus.FollowWithSubscriptionID("billing-projector"),
+)
+```
+
+With a subscription ID, the follower saves its position after each processed
+event (via the `SubscriptionStore`) and resumes there after a restart. The
+first run consumes the log from the beginning (or from `FollowFrom` if
+given). Without a subscription ID, `Follow` starts at the tail: live events
+only.
+
+## At-least-once, and what to do about it
+
+Every layer of a shared log is at-least-once: appends may be retried, chunked
+reads may re-deliver on resume, a crash between handling and offset save
+replays. ebu absorbs most duplicates for you:
+
+- Every publish gets a ULID `Event.ID`, minted **before** the first append
+  attempt — retried appends carry the same ID.
+- The follower drops IDs it has recently seen (`FollowDedupWindow`, default
+  1024; `0` disables).
+
+For stronger guarantees (e.g. duplicates arriving outside the window, or two
+followers of the same subscription), make handlers idempotent keyed on the
+event ID — `EventIDFromContext(ctx)` in live/followed handlers,
+`StoredEvent.ID` in replay.
+
+## Semantics inside followed handlers
+
+Dispatch is identical to a local publish: filters, `Once()`, `Async()`,
+`Sequential()`, and panic recovery all apply, and `OffsetFromContext`,
+`EventIDFromContext`, and `MetadataFromContext` work. Publish *hooks* and
+publish-level observability do not re-fire (they fired in the publishing
+process); handler-level observability does.
+
+Registered upcasts are applied before decoding, so old events on the stream
+arrive in their current schema — same as `Replay`.
+
+## Failure behavior
+
+- **Read/tail errors**: reported to the `PersistenceErrorHandler`, retried
+  after `FollowPollInterval`. The follower does not die.
+- **Poison events** (payload does not decode into the subscribed type):
+  reported with the `*StoredEvent` for out-of-band recovery, then skipped.
+- **Unsubscribed types**: skipped silently — streams may carry many types.
+- `Follow` itself returns only on context cancellation or invalid
+  configuration.
+
+## Current limitations (roadmap)
+
+- **Competing consumers**: one durable subscription ID should be followed by
+  one process at a time; there is no lease/lock yet. Running two followers
+  on the same ID delivers duplicates (the dedup window absorbs some) and
+  interleaves offset saves. Planned: offset leases and key-based
+  partitioning for ordered scale-out.
+- **Backends**: sqlite works cross-process on one machine (WAL) and
+  durable-streams over the network. A Postgres store (table +
+  LISTEN/NOTIFY tail) is the natural next backend; the `EventStore` +
+  `EventStoreTailer` interfaces are all it needs to implement.

--- a/event_bus.go
+++ b/event_bus.go
@@ -93,6 +93,18 @@ type EventBus struct {
 	// their own events apart from a peer's.
 	originID string
 
+	// logDelivery, when set, makes the store the only delivery path: Publish
+	// appends to the log and never dispatches locally; handlers receive
+	// events exclusively from a Follow loop (see WithLogDelivery).
+	logDelivery bool
+
+	// followDecoders maps a persisted type name to a closure that decodes a
+	// stored event into its Go type and dispatches it locally. Entries are
+	// registered by the generic Subscribe* entry points, which are the only
+	// places the concrete type is statically known.
+	followMu       sync.RWMutex
+	followDecoders map[string]followDecoder
+
 	// Upcast registry for event migration
 	upcastRegistry *upcastRegistry
 
@@ -206,6 +218,7 @@ func New(opts ...Option) *EventBus {
 	bus := &EventBus{
 		upcastRegistry: newUpcastRegistry(),
 		originID:       NewEventID(),
+		followDecoders: make(map[string]followDecoder),
 	}
 	bus.asyncCond = sync.NewCond(&bus.asyncMu)
 
@@ -219,6 +232,13 @@ func New(opts ...Option) *EventBus {
 	// Apply options
 	for _, opt := range opts {
 		opt(bus)
+	}
+
+	// Log-delivery mode without a store would silently drop every publish
+	// (nothing appends, nothing follows). That is a configuration bug, not a
+	// runtime condition — fail loudly at construction, mirroring WithUpcast.
+	if bus.logDelivery && bus.store == nil {
+		panic("eventbus: WithLogDelivery requires WithStore: without a store there is no log to deliver from")
 	}
 
 	return bus
@@ -334,6 +354,7 @@ func SubscribeWithHandle[T any](bus *EventBus, handler Handler[T], opts ...Subsc
 	}
 
 	bus.addHandler(eventType, h)
+	registerFollowDecoder[T](bus)
 	return &Subscription{bus: bus, eventType: eventType, h: h}, nil
 }
 
@@ -355,6 +376,7 @@ func SubscribeContextWithHandle[T any](bus *EventBus, handler ContextHandler[T],
 	}
 
 	bus.addHandler(eventType, h)
+	registerFollowDecoder[T](bus)
 	return &Subscription{bus: bus, eventType: eventType, h: h}, nil
 }
 
@@ -379,6 +401,7 @@ func Subscribe[T any](bus *EventBus, handler Handler[T], opts ...SubscribeOption
 	}
 
 	bus.addHandler(eventType, h)
+	registerFollowDecoder[T](bus)
 	return nil
 }
 
@@ -400,6 +423,7 @@ func SubscribeContext[T any](bus *EventBus, handler ContextHandler[T], opts ...S
 	}
 
 	bus.addHandler(eventType, h)
+	registerFollowDecoder[T](bus)
 	return nil
 }
 
@@ -534,21 +558,51 @@ func publishContext[T any](bus *EventBus, ctx context.Context, event T) error {
 
 	// In strict mode a failed persist skips delivery: handlers never observe
 	// an event the log did not record, so replay and live handling can never
-	// diverge. The after-publish hooks and observability below still fire so
-	// monitoring sees the attempt.
-	deliver := persistErr == nil || !bus.strictPersistence
+	// diverge. In log-delivery mode (WithLogDelivery) local dispatch is
+	// always skipped: delivery happens exclusively through the follower
+	// tailing the store (see Follow), so every process — including this one —
+	// observes the same events in the same order. The after-publish hooks and
+	// observability below still fire so monitoring sees the attempt.
+	deliver := (persistErr == nil || !bus.strictPersistence) && !bus.logDelivery
 
+	if deliver {
+		dispatch(bus, ctx, eventType, eventTypeName, event)
+	}
+
+	// For async handlers, we don't wait inline to avoid blocking
+	// Users can call bus.Wait() if they need to wait for completion
+
+	// Call after publish hooks
+	if bus.afterPublish != nil {
+		bus.afterPublish(eventType, event)
+	}
+	if bus.afterPublishCtx != nil {
+		bus.afterPublishCtx(ctx, eventType, event)
+	}
+
+	// Observability: Track publish complete (sync handlers done)
+	if bus.observability != nil {
+		bus.observability.OnPublishComplete(ctx, eventTypeName)
+	}
+
+	return persistErr
+}
+
+// dispatch delivers an event to the handlers registered for eventType. It is
+// the delivery half of the publish path, shared by publishContext (live
+// publishes) and the follower (events read back from a shared store): all
+// subscription options — filters, Once, Async, Sequential — behave
+// identically on both paths. It does not run the publish hooks or
+// publish-level observability; those belong to the publish, not to delivery.
+func dispatch[T any](bus *EventBus, ctx context.Context, eventType reflect.Type, eventTypeName string, event T) {
 	// Get handlers from appropriate shard
 	shard := bus.getShard(eventType)
-	var handlersCopy []*internalHandler
-	if deliver {
-		shard.mu.RLock()
-		handlers := shard.handlers[eventType]
-		// Create a copy to avoid holding the lock during handler execution
-		handlersCopy = make([]*internalHandler, len(handlers))
-		copy(handlersCopy, handlers)
-		shard.mu.RUnlock()
-	}
+	shard.mu.RLock()
+	handlers := shard.handlers[eventType]
+	// Create a copy to avoid holding the lock during handler execution
+	handlersCopy := make([]*internalHandler, len(handlers))
+	copy(handlersCopy, handlers)
+	shard.mu.RUnlock()
 
 	// Execute handlers without holding the lock
 	var onceHandlersToRemove []*internalHandler
@@ -628,24 +682,6 @@ func publishContext[T any](bus *EventBus, ctx context.Context, event T) error {
 		shard.handlers[eventType] = handlers
 		shard.mu.Unlock()
 	}
-
-	// For async handlers, we don't wait inline to avoid blocking
-	// Users can call bus.Wait() if they need to wait for completion
-
-	// Call after publish hooks
-	if bus.afterPublish != nil {
-		bus.afterPublish(eventType, event)
-	}
-	if bus.afterPublishCtx != nil {
-		bus.afterPublishCtx(ctx, eventType, event)
-	}
-
-	// Observability: Track publish complete (sync handlers done)
-	if bus.observability != nil {
-		bus.observability.OnPublishComplete(ctx, eventTypeName)
-	}
-
-	return persistErr
 }
 
 // Clear removes all handlers for events of type T

--- a/follow.go
+++ b/follow.go
@@ -1,0 +1,447 @@
+package eventbus
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"iter"
+	"reflect"
+	"time"
+)
+
+// EventStoreTailer is an optional interface for stores that can push new
+// events as they arrive instead of being polled. When the bus's store
+// implements it, Follow uses Tail; otherwise it falls back to polling Read
+// on the configured interval (see FollowPollInterval).
+//
+// Contract:
+//   - Tail yields events strictly after from, in order, as they become
+//     available, blocking between events rather than returning at the tail.
+//   - from accepts the same values as Read: OffsetOldest, OffsetNewest
+//     (resolved to the tail at call time), or any offset the store issued.
+//   - The iterator ends after yielding a non-nil error, or silently when ctx
+//     is cancelled. Follow restarts a tail that ends for any other reason.
+type EventStoreTailer interface {
+	Tail(ctx context.Context, from Offset) iter.Seq2[*StoredEvent, error]
+}
+
+// followDecoder decodes a stored event's payload into its Go type and
+// dispatches it to local handlers. Implementations are closures created by
+// registerFollowDecoder, the only place the concrete type is known.
+type followDecoder func(ctx context.Context, data json.RawMessage) error
+
+// registerFollowDecoder records how to decode and locally dispatch events of
+// type T, keyed by T's persisted type name. Every generic subscribe entry
+// point calls it, so by the time a Follow loop runs, each subscribed type
+// can be delivered from the store. Idempotent; safe for concurrent use.
+func registerFollowDecoder[T any](bus *EventBus) {
+	eventType := reflect.TypeOf((*T)(nil)).Elem()
+	typeName := typeNameOf(eventType)
+
+	bus.followMu.Lock()
+	defer bus.followMu.Unlock()
+	if _, ok := bus.followDecoders[typeName]; ok {
+		return
+	}
+	bus.followDecoders[typeName] = func(ctx context.Context, data json.RawMessage) error {
+		var event T
+		if err := json.Unmarshal(data, &event); err != nil {
+			return err
+		}
+		dispatch(bus, ctx, eventType, typeName, event)
+		return nil
+	}
+}
+
+// WithLogDelivery makes the store the only delivery path: Publish appends to
+// the log and returns without dispatching to local handlers; handlers receive
+// events exclusively from a Follow loop tailing that log. Because every
+// process — including the publisher — then observes the same log, all of them
+// see the same events in the same order, and a publish that failed to persist
+// is (by construction) never observed anywhere.
+//
+// Requirements: WithStore is mandatory (New panics without it), and the
+// process must run bus.Follow, or published events are stored but never
+// handled locally. Publish hooks and publish-level observability still fire
+// at publish time; handler execution happens on the Follow goroutine.
+func WithLogDelivery() Option {
+	return func(bus *EventBus) {
+		bus.logDelivery = true
+	}
+}
+
+// FollowOption configures a Follow loop.
+type FollowOption func(*followConfig) error
+
+type followConfig struct {
+	from         Offset
+	fromSet      bool
+	subscription string
+	pollInterval time.Duration
+	includeOwn   bool
+	dedupWindow  int
+}
+
+// FollowFrom sets the offset the follower starts reading after. The default
+// is OffsetNewest (live-only). With FollowWithSubscriptionID, a saved offset
+// takes precedence and FollowFrom applies only to the first run (no saved
+// offset yet); without a subscription ID it applies to every call.
+func FollowFrom(from Offset) FollowOption {
+	return func(cfg *followConfig) error {
+		cfg.from = from
+		cfg.fromSet = true
+		return nil
+	}
+}
+
+// FollowWithSubscriptionID makes the follower durable: it resumes from the
+// offset saved under id and saves its position as it processes events, so a
+// restarted process continues where it left off. Requires a SubscriptionStore
+// (WithSubscriptionStore, or a store that implements it). On the first run —
+// no saved offset — it starts from FollowFrom if given, else OffsetOldest.
+//
+// Progress is saved after each processed event; delivery is at-least-once
+// across restarts. Use FollowDedupWindow and StoredEvent.ID to absorb the
+// duplicates.
+func FollowWithSubscriptionID(id string) FollowOption {
+	return func(cfg *followConfig) error {
+		if id == "" {
+			return fmt.Errorf("eventbus: follow subscription ID cannot be empty")
+		}
+		cfg.subscription = id
+		return nil
+	}
+}
+
+// FollowPollInterval sets how long the follower sleeps between Read calls
+// when the store does not implement EventStoreTailer, and how long it backs
+// off after a read error on either path. Default 200ms.
+func FollowPollInterval(d time.Duration) FollowOption {
+	return func(cfg *followConfig) error {
+		if d <= 0 {
+			return fmt.Errorf("eventbus: follow poll interval must be positive")
+		}
+		cfg.pollInterval = d
+		return nil
+	}
+}
+
+// FollowIncludeOwn delivers events this bus instance itself published
+// (matched by Origin). By default the follower skips them, because in the
+// default delivery mode they were already dispatched locally at publish time
+// and would arrive twice. A bus in WithLogDelivery mode always receives its
+// own events from the log regardless of this option — there, the log is the
+// only delivery path.
+func FollowIncludeOwn() FollowOption {
+	return func(cfg *followConfig) error {
+		cfg.includeOwn = true
+		return nil
+	}
+}
+
+// FollowDedupWindow sets how many recently seen event IDs the follower
+// remembers to drop at-least-once duplicates (retried appends, chunk
+// re-reads, replays after a crash). Default 1024; 0 disables deduplication.
+// Events without an ID (written by pre-envelope versions or external
+// producers) are never deduplicated.
+func FollowDedupWindow(n int) FollowOption {
+	return func(cfg *followConfig) error {
+		if n < 0 {
+			return fmt.Errorf("eventbus: follow dedup window cannot be negative")
+		}
+		cfg.dedupWindow = n
+		return nil
+	}
+}
+
+// dedupRing remembers the last N event IDs seen. Follow runs single-threaded,
+// so it needs no locking.
+type dedupRing struct {
+	ids  map[string]struct{}
+	ring []string
+	next int
+}
+
+func newDedupRing(n int) *dedupRing {
+	return &dedupRing{
+		ids:  make(map[string]struct{}, n),
+		ring: make([]string, n),
+	}
+}
+
+// observe records id and reports whether it had been seen already.
+func (r *dedupRing) observe(id string) bool {
+	if _, ok := r.ids[id]; ok {
+		return true
+	}
+	if evicted := r.ring[r.next]; evicted != "" {
+		delete(r.ids, evicted)
+	}
+	r.ring[r.next] = id
+	r.next = (r.next + 1) % len(r.ring)
+	r.ids[id] = struct{}{}
+	return false
+}
+
+// Follow tails the bus's event store and delivers each new event to the
+// local handlers subscribed to its type. It is the primitive that turns a
+// shared store into a cross-process bus: every process appends by
+// publishing and receives by following.
+//
+// Follow blocks until ctx is cancelled (returning ctx.Err()) or startup
+// validation fails. Run it on its own goroutine:
+//
+//	go func() {
+//	    if err := bus.Follow(ctx); err != nil && !errors.Is(err, context.Canceled) {
+//	        log.Printf("follower stopped: %v", err)
+//	    }
+//	}()
+//
+// Delivery semantics:
+//   - Events are dispatched with the same semantics as a local publish —
+//     filters, Once, Async, Sequential, and panic recovery all apply — but
+//     publish hooks and publish-level observability do not fire (they fired
+//     in the publishing process). OffsetFromContext, EventIDFromContext, and
+//     MetadataFromContext work inside handlers.
+//   - Only event types with at least one prior Subscribe* call in this
+//     process can be decoded; events of other types are skipped. Subscribe
+//     BEFORE calling Follow — types subscribed later are only picked up from
+//     that point in the stream onward.
+//   - Events this bus itself published are skipped unless FollowIncludeOwn
+//     is given or the bus is in WithLogDelivery mode (see those options).
+//   - Registered upcasts are applied before decoding, exactly as in Replay.
+//   - Delivery is at-least-once end to end. The follower deduplicates by
+//     StoredEvent.ID within FollowDedupWindow; handlers that need stronger
+//     guarantees must be idempotent.
+//
+// Failure handling: read errors and undecodable (poison) events are reported
+// to the PersistenceErrorHandler; reads are retried after FollowPollInterval,
+// poison events are skipped so they cannot wedge the follower. Follow itself
+// only returns on ctx cancellation or invalid configuration.
+func (bus *EventBus) Follow(ctx context.Context, opts ...FollowOption) error {
+	if bus.store == nil {
+		return fmt.Errorf("eventbus: Follow requires persistence (use WithStore option)")
+	}
+
+	cfg := &followConfig{
+		from:         OffsetNewest,
+		pollInterval: 200 * time.Millisecond,
+		dedupWindow:  1024,
+	}
+	for _, opt := range opts {
+		if opt == nil {
+			return fmt.Errorf("eventbus: follow option cannot be nil")
+		}
+		if err := opt(cfg); err != nil {
+			return err
+		}
+	}
+
+	// Resolve the durable subscription store, mirroring SubscribeWithReplay.
+	var subStore SubscriptionStore
+	if cfg.subscription != "" {
+		subStore = bus.subscriptionStore
+		if subStore == nil {
+			if ss, ok := bus.store.(SubscriptionStore); ok {
+				subStore = ss
+			} else {
+				return fmt.Errorf("eventbus: FollowWithSubscriptionID requires a SubscriptionStore (use WithSubscriptionStore option or use a store that implements SubscriptionStore)")
+			}
+		}
+	}
+
+	from := cfg.from
+	if subStore != nil {
+		saved, err := subStore.LoadOffset(ctx, cfg.subscription)
+		if err != nil {
+			return fmt.Errorf("eventbus: load follow offset for %q: %w", cfg.subscription, err)
+		}
+		if saved != OffsetOldest {
+			from = saved
+		} else if !cfg.fromSet {
+			// First run of a durable follower: consume the full log so the
+			// subscription's view is complete, like SubscribeWithReplay.
+			from = OffsetOldest
+		}
+	}
+
+	var dedup *dedupRing
+	if cfg.dedupWindow > 0 {
+		dedup = newDedupRing(cfg.dedupWindow)
+	}
+
+	f := &follower{bus: bus, cfg: cfg, subStore: subStore, dedup: dedup, offset: from}
+	if tailer, ok := bus.store.(EventStoreTailer); ok {
+		return f.runTail(ctx, tailer)
+	}
+	return f.runPoll(ctx)
+}
+
+// follower is the running state of one Follow call.
+type follower struct {
+	bus      *EventBus
+	cfg      *followConfig
+	subStore SubscriptionStore
+	dedup    *dedupRing
+	offset   Offset
+}
+
+// runPoll reads batches in a sleep loop; the fallback for stores without
+// EventStoreTailer support.
+func (f *follower) runPoll(ctx context.Context) error {
+	batchSize := f.bus.replayBatchSize
+	if batchSize <= 0 {
+		batchSize = 100
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		events, next, err := f.bus.store.Read(ctx, f.offset, batchSize)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			f.reportError(fmt.Errorf("follow: read after offset %s: %w", f.offset, err))
+			if err := sleepCtx(ctx, f.cfg.pollInterval); err != nil {
+				return err
+			}
+			continue
+		}
+
+		for _, stored := range events {
+			f.processEvent(ctx, stored)
+		}
+
+		if next == f.offset {
+			// At the tail (or the store cannot advance): wait for new events.
+			if err := sleepCtx(ctx, f.cfg.pollInterval); err != nil {
+				return err
+			}
+			continue
+		}
+		f.advance(ctx, next)
+	}
+}
+
+// runTail consumes a pushing store, restarting the tail after errors.
+func (f *follower) runTail(ctx context.Context, tailer EventStoreTailer) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		var tailErr error
+		for stored, err := range tailer.Tail(ctx, f.offset) {
+			if err != nil {
+				tailErr = err
+				break
+			}
+			f.processEvent(ctx, stored)
+			f.advance(ctx, stored.Offset)
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if tailErr != nil {
+			f.reportError(fmt.Errorf("follow: tail after offset %s: %w", f.offset, tailErr))
+		}
+		// Either an error or a tail that ended unexpectedly: back off and
+		// re-tail from the last processed position.
+		if err := sleepCtx(ctx, f.cfg.pollInterval); err != nil {
+			return err
+		}
+	}
+}
+
+// processEvent runs one stored event through dedup, origin filtering,
+// upcasting, decoding, and local dispatch. Undeliverable events (duplicates,
+// own-origin echoes, unsubscribed types, poison payloads) are skipped — a
+// follower must keep up with the stream no matter what is on it.
+func (f *follower) processEvent(ctx context.Context, stored *StoredEvent) {
+	if f.dedup != nil && stored.ID != "" && f.dedup.observe(stored.ID) {
+		return
+	}
+
+	// Skip this bus's own events: in the default delivery mode they were
+	// already dispatched locally at publish time. In log-delivery mode the
+	// log is the only delivery path, so own events are always taken.
+	if stored.Origin == f.bus.originID && !f.cfg.includeOwn && !f.bus.logDelivery {
+		return
+	}
+
+	data, typeName := stored.Data, stored.Type
+	if upcasted, upcastedType, err := f.bus.upcastRegistry.apply(data, typeName); err == nil {
+		data, typeName = upcasted, upcastedType
+	}
+	// On upcast failure the original payload proceeds; the type check or
+	// decode below decides its fate, mirroring replay behavior.
+
+	f.bus.followMu.RLock()
+	decode := f.bus.followDecoders[typeName]
+	f.bus.followMu.RUnlock()
+	if decode == nil {
+		return // No local subscriber for this type.
+	}
+
+	// Hand handlers the same context values a live publish would carry.
+	dctx := ctx
+	if stored.Offset != OffsetOldest {
+		dctx = context.WithValue(dctx, offsetCtxKey{}, stored.Offset)
+	}
+	if stored.ID != "" {
+		dctx = context.WithValue(dctx, eventIDCtxKey{}, stored.ID)
+	}
+	dctx = ContextWithMetadata(dctx, stored.Metadata)
+
+	if err := decode(dctx, data); err != nil {
+		// Poison event: report and move on. The payload travels with the
+		// report for out-of-band recovery, as in SubscribeWithReplay.
+		f.reportEvent(stored, fmt.Errorf("follow: skipping undecodable event at offset %s: %w", stored.Offset, err))
+	}
+}
+
+// advance records the follower's position, persisting it for durable
+// followers. SaveOffset failures are reported and do not stop the follower:
+// the position is redundant with the events themselves (at-least-once).
+func (f *follower) advance(ctx context.Context, offset Offset) {
+	f.offset = offset
+	if f.subStore == nil {
+		return
+	}
+	if err := f.subStore.SaveOffset(ctx, f.cfg.subscription, offset); err != nil {
+		f.reportError(fmt.Errorf("follow: save offset for %q: %w", f.cfg.subscription, err))
+	}
+}
+
+// reportError forwards a follower failure to the PersistenceErrorHandler,
+// the bus's monitoring channel for storage problems. The event argument is
+// nil for failures not tied to a specific event.
+func (f *follower) reportError(err error) {
+	if f.bus.persistenceErrorHandler != nil {
+		f.bus.persistenceErrorHandler(nil, nil, err)
+	}
+}
+
+// reportEvent forwards a per-event failure, carrying the *StoredEvent so the
+// payload can be recovered out of band.
+func (f *follower) reportEvent(stored *StoredEvent, err error) {
+	if f.bus.persistenceErrorHandler != nil {
+		f.bus.persistenceErrorHandler(stored, nil, err)
+	}
+}
+
+// sleepCtx sleeps for d or until ctx is done, returning ctx.Err() in the
+// latter case.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/follow_test.go
+++ b/follow_test.go
@@ -1,0 +1,758 @@
+package eventbus
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"iter"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type followEvent struct {
+	Value int
+}
+
+// waitFor polls cond until it holds or the timeout expires.
+func waitFor(t *testing.T, timeout time.Duration, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// startFollower runs bus.Follow on a goroutine and returns a stop function
+// that cancels it and waits for it to return.
+func startFollower(t *testing.T, bus *EventBus, opts ...FollowOption) (stop func()) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- bus.Follow(ctx, opts...) }()
+	return func() {
+		cancel()
+		select {
+		case err := <-done:
+			if !errors.Is(err, context.Canceled) {
+				t.Errorf("Follow returned %v, want context.Canceled", err)
+			}
+		case <-time.After(5 * time.Second):
+			t.Error("Follow did not return after cancel")
+		}
+	}
+}
+
+// fastPoll keeps follower tests snappy.
+var fastPoll = FollowPollInterval(2 * time.Millisecond)
+
+func TestFollowCrossBusDelivery(t *testing.T) {
+	store := NewMemoryStore()
+	publisher := New(WithStore(store))
+	consumer := New(WithStore(store))
+
+	var got []int
+	var mu sync.Mutex
+	Subscribe(consumer, func(e followEvent) {
+		mu.Lock()
+		got = append(got, e.Value)
+		mu.Unlock()
+	})
+
+	stop := startFollower(t, consumer, FollowFrom(OffsetOldest), fastPoll)
+	defer stop()
+
+	for i := 1; i <= 3; i++ {
+		Publish(publisher, followEvent{Value: i})
+	}
+
+	waitFor(t, 5*time.Second, "cross-bus delivery", func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(got) == 3
+	})
+	mu.Lock()
+	defer mu.Unlock()
+	for i, v := range got {
+		if v != i+1 {
+			t.Errorf("event %d: got %d, want %d (stream order must be preserved)", i, v, i+1)
+		}
+	}
+}
+
+func TestFollowSkipsOwnEventsByDefault(t *testing.T) {
+	store := NewMemoryStore()
+	bus := New(WithStore(store))
+
+	var count atomic.Int32
+	Subscribe(bus, func(e followEvent) { count.Add(1) })
+
+	stop := startFollower(t, bus, FollowFrom(OffsetOldest), fastPoll)
+	defer stop()
+
+	Publish(bus, followEvent{Value: 1}) // delivered locally at publish time
+
+	// Give the follower ample time to (incorrectly) echo the event back.
+	time.Sleep(50 * time.Millisecond)
+	if n := count.Load(); n != 1 {
+		t.Errorf("expected exactly 1 delivery (live only), got %d", n)
+	}
+}
+
+func TestFollowIncludeOwnDeliversTwice(t *testing.T) {
+	store := NewMemoryStore()
+	bus := New(WithStore(store))
+
+	var count atomic.Int32
+	Subscribe(bus, func(e followEvent) { count.Add(1) })
+
+	stop := startFollower(t, bus, FollowFrom(OffsetOldest), fastPoll, FollowIncludeOwn())
+	defer stop()
+
+	Publish(bus, followEvent{Value: 1})
+
+	waitFor(t, 5*time.Second, "own-event echo", func() bool { return count.Load() == 2 })
+}
+
+func TestWithLogDeliveryPublishesOnlyThroughFollower(t *testing.T) {
+	store := NewMemoryStore()
+	bus := New(WithStore(store), WithLogDelivery())
+
+	var got []int
+	var mu sync.Mutex
+	SubscribeContext(bus, func(ctx context.Context, e followEvent) {
+		if _, ok := OffsetFromContext(ctx); !ok {
+			t.Error("log-delivered event must carry its offset")
+		}
+		if _, ok := EventIDFromContext(ctx); !ok {
+			t.Error("log-delivered event must carry its ID")
+		}
+		mu.Lock()
+		got = append(got, e.Value)
+		mu.Unlock()
+	})
+
+	// Without a follower, publishes append to the log but deliver nothing.
+	Publish(bus, followEvent{Value: 1})
+	Publish(bus, followEvent{Value: 2})
+	mu.Lock()
+	if len(got) != 0 {
+		t.Fatalf("log-delivery mode must not dispatch at publish time, got %v", got)
+	}
+	mu.Unlock()
+
+	stop := startFollower(t, bus, FollowFrom(OffsetOldest), fastPoll)
+	defer stop()
+
+	Publish(bus, followEvent{Value: 3})
+
+	waitFor(t, 5*time.Second, "log delivery", func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(got) == 3
+	})
+	mu.Lock()
+	defer mu.Unlock()
+	for i, v := range got {
+		if v != i+1 {
+			t.Errorf("position %d: got %d, want %d (log order)", i, v, i+1)
+		}
+	}
+}
+
+func TestWithLogDeliveryIdenticalOrderAcrossBuses(t *testing.T) {
+	store := NewMemoryStore()
+	busA := New(WithStore(store), WithLogDelivery())
+	busB := New(WithStore(store), WithLogDelivery())
+
+	var gotA, gotB []int
+	var mu sync.Mutex
+	Subscribe(busA, func(e followEvent) { mu.Lock(); gotA = append(gotA, e.Value); mu.Unlock() })
+	Subscribe(busB, func(e followEvent) { mu.Lock(); gotB = append(gotB, e.Value); mu.Unlock() })
+
+	stopA := startFollower(t, busA, FollowFrom(OffsetOldest), fastPoll)
+	defer stopA()
+	stopB := startFollower(t, busB, FollowFrom(OffsetOldest), fastPoll)
+	defer stopB()
+
+	// Interleave publishers: the log serializes them into one total order.
+	var wg sync.WaitGroup
+	for i := 1; i <= 10; i++ {
+		wg.Add(1)
+		go func(v int) {
+			defer wg.Done()
+			if v%2 == 0 {
+				Publish(busA, followEvent{Value: v})
+			} else {
+				Publish(busB, followEvent{Value: v})
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	waitFor(t, 5*time.Second, "both buses to consume the log", func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(gotA) == 10 && len(gotB) == 10
+	})
+	mu.Lock()
+	defer mu.Unlock()
+	for i := range gotA {
+		if gotA[i] != gotB[i] {
+			t.Fatalf("order diverged at %d: A=%v B=%v", i, gotA, gotB)
+		}
+	}
+}
+
+func TestFollowDefaultStartsAtTail(t *testing.T) {
+	store := NewMemoryStore()
+	publisher := New(WithStore(store))
+	consumer := New(WithStore(store))
+
+	Publish(publisher, followEvent{Value: 1}) // history: must NOT be delivered
+
+	var count atomic.Int32
+	Subscribe(consumer, func(e followEvent) { count.Add(1) })
+
+	stop := startFollower(t, consumer, fastPoll)
+	defer stop()
+
+	// Wait until the follower has resolved the tail, then publish live.
+	time.Sleep(20 * time.Millisecond)
+	Publish(publisher, followEvent{Value: 2})
+
+	waitFor(t, 5*time.Second, "live event", func() bool { return count.Load() >= 1 })
+	time.Sleep(20 * time.Millisecond)
+	if n := count.Load(); n != 1 {
+		t.Errorf("expected only the live event, got %d deliveries", n)
+	}
+}
+
+func TestFollowDurableResume(t *testing.T) {
+	store := NewMemoryStore()
+	publisher := New(WithStore(store))
+	consumer := New(WithStore(store))
+
+	var count atomic.Int32
+	Subscribe(consumer, func(e followEvent) { count.Add(1) })
+
+	Publish(publisher, followEvent{Value: 1})
+	Publish(publisher, followEvent{Value: 2})
+
+	// First run: no saved offset, durable followers consume the full log.
+	stop := startFollower(t, consumer, fastPoll, FollowWithSubscriptionID("proj"))
+	waitFor(t, 5*time.Second, "first run", func() bool { return count.Load() == 2 })
+	stop()
+
+	Publish(publisher, followEvent{Value: 3})
+	Publish(publisher, followEvent{Value: 4})
+
+	// Second run resumes after the saved offset: only the new events arrive.
+	stop = startFollower(t, consumer, fastPoll, FollowWithSubscriptionID("proj"))
+	defer stop()
+	waitFor(t, 5*time.Second, "resumed run", func() bool { return count.Load() == 4 })
+	time.Sleep(20 * time.Millisecond)
+	if n := count.Load(); n != 4 {
+		t.Errorf("expected 4 total deliveries (no replays), got %d", n)
+	}
+}
+
+func TestFollowDedupDropsDuplicateIDs(t *testing.T) {
+	store := NewMemoryStore()
+	consumer := New(WithStore(store))
+
+	var count atomic.Int32
+	Subscribe(consumer, func(e followEvent) { count.Add(1) })
+
+	// Two log entries with the same event ID: an at-least-once duplicate.
+	dup := &Event{ID: NewEventID(), Type: "eventbus.followEvent", Data: json.RawMessage(`{"Value":1}`), Timestamp: time.Now()}
+	ctx := context.Background()
+	if _, err := store.Append(ctx, dup); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Append(ctx, dup); err != nil {
+		t.Fatal(err)
+	}
+
+	stop := startFollower(t, consumer, FollowFrom(OffsetOldest), fastPoll)
+	defer stop()
+
+	waitFor(t, 5*time.Second, "delivery", func() bool { return count.Load() >= 1 })
+	time.Sleep(20 * time.Millisecond)
+	if n := count.Load(); n != 1 {
+		t.Errorf("expected the duplicate to be dropped, got %d deliveries", n)
+	}
+}
+
+func TestFollowDedupWindowZeroDisables(t *testing.T) {
+	store := NewMemoryStore()
+	consumer := New(WithStore(store))
+
+	var count atomic.Int32
+	Subscribe(consumer, func(e followEvent) { count.Add(1) })
+
+	dup := &Event{ID: NewEventID(), Type: "eventbus.followEvent", Data: json.RawMessage(`{"Value":1}`), Timestamp: time.Now()}
+	ctx := context.Background()
+	for i := 0; i < 2; i++ {
+		if _, err := store.Append(ctx, dup); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stop := startFollower(t, consumer, FollowFrom(OffsetOldest), fastPoll, FollowDedupWindow(0))
+	defer stop()
+
+	waitFor(t, 5*time.Second, "both duplicates", func() bool { return count.Load() == 2 })
+}
+
+func TestDedupRingEviction(t *testing.T) {
+	r := newDedupRing(2)
+	if r.observe("a") || r.observe("b") {
+		t.Fatal("fresh IDs must not read as seen")
+	}
+	if !r.observe("a") {
+		t.Fatal("a is within the window and must read as seen")
+	}
+	// c evicts the oldest slot; after d, a is long gone.
+	r.observe("c")
+	r.observe("d")
+	if r.observe("a") {
+		t.Error("a should have been evicted from a window of 2")
+	}
+}
+
+func TestFollowSkipsPoisonAndUnknownTypes(t *testing.T) {
+	store := NewMemoryStore()
+	consumer := New(WithStore(store))
+
+	var reports []error
+	var mu sync.Mutex
+	consumer.SetPersistenceErrorHandler(func(event any, eventType reflect.Type, err error) {
+		mu.Lock()
+		reports = append(reports, err)
+		mu.Unlock()
+	})
+
+	var count atomic.Int32
+	Subscribe(consumer, func(e followEvent) { count.Add(1) })
+
+	ctx := context.Background()
+	appendRaw := func(typeName, data string) {
+		t.Helper()
+		if _, err := store.Append(ctx, &Event{ID: NewEventID(), Type: typeName, Data: json.RawMessage(data), Timestamp: time.Now()}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	appendRaw("eventbus.followEvent", `{"Value":"poison"}`) // wrong field type: undecodable
+	appendRaw("some.unsubscribed.type", `{}`)               // no local subscriber
+	appendRaw("eventbus.followEvent", `{"Value":7}`)        // healthy
+
+	stop := startFollower(t, consumer, FollowFrom(OffsetOldest), fastPoll)
+	defer stop()
+
+	waitFor(t, 5*time.Second, "healthy event after poison", func() bool { return count.Load() == 1 })
+	mu.Lock()
+	defer mu.Unlock()
+	if len(reports) != 1 {
+		t.Fatalf("expected exactly one poison report, got %d: %v", len(reports), reports)
+	}
+}
+
+type followV1 struct {
+	Name string
+}
+
+type followV2 struct {
+	FullName string
+}
+
+func TestFollowAppliesUpcasts(t *testing.T) {
+	store := NewMemoryStore()
+	consumer := New(WithStore(store))
+	if err := RegisterUpcast(consumer, func(v1 followV1) followV2 {
+		return followV2{FullName: v1.Name}
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var got atomic.Value
+	Subscribe(consumer, func(e followV2) { got.Store(e.FullName) })
+
+	if _, err := store.Append(context.Background(), &Event{
+		ID: NewEventID(), Type: "eventbus.followV1", Data: json.RawMessage(`{"Name":"Ada"}`), Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stop := startFollower(t, consumer, FollowFrom(OffsetOldest), fastPoll)
+	defer stop()
+
+	waitFor(t, 5*time.Second, "upcasted delivery", func() bool { return got.Load() != nil })
+	if v := got.Load(); v != "Ada" {
+		t.Errorf("got %v, want Ada", v)
+	}
+}
+
+// bareStore implements only EventStore — no SubscriptionStore — to exercise
+// the FollowWithSubscriptionID validation path.
+type bareStore struct {
+	inner *MemoryStore
+}
+
+func (b *bareStore) Append(ctx context.Context, event *Event) (Offset, error) {
+	return b.inner.Append(ctx, event)
+}
+
+func (b *bareStore) Read(ctx context.Context, from Offset, limit int) ([]*StoredEvent, Offset, error) {
+	return b.inner.Read(ctx, from, limit)
+}
+
+func TestFollowValidation(t *testing.T) {
+	ctx := context.Background()
+
+	if err := New().Follow(ctx); err == nil {
+		t.Error("expected error without a store")
+	}
+
+	bus := New(WithStore(NewMemoryStore()))
+	if err := bus.Follow(ctx, nil); err == nil {
+		t.Error("expected error for nil option")
+	}
+	if err := bus.Follow(ctx, FollowWithSubscriptionID("")); err == nil {
+		t.Error("expected error for empty subscription ID")
+	}
+	if err := bus.Follow(ctx, FollowPollInterval(0)); err == nil {
+		t.Error("expected error for non-positive poll interval")
+	}
+	if err := bus.Follow(ctx, FollowDedupWindow(-1)); err == nil {
+		t.Error("expected error for negative dedup window")
+	}
+
+	bare := New(WithStore(&bareStore{inner: NewMemoryStore()}))
+	if err := bare.Follow(ctx, FollowWithSubscriptionID("x")); err == nil {
+		t.Error("expected error when no SubscriptionStore is available")
+	}
+}
+
+func TestWithLogDeliveryWithoutStorePanics(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Error("expected New(WithLogDelivery()) without a store to panic")
+		}
+	}()
+	New(WithLogDelivery())
+}
+
+// flakyStore fails operations a set number of times before delegating,
+// exercising the follower's retry paths.
+type flakyStore struct {
+	*MemoryStore
+	readFails atomic.Int32
+	saveFails atomic.Int32
+	loadFails atomic.Int32
+}
+
+func (f *flakyStore) Read(ctx context.Context, from Offset, limit int) ([]*StoredEvent, Offset, error) {
+	if f.readFails.Add(-1) >= 0 {
+		return nil, from, errors.New("transient read failure")
+	}
+	return f.MemoryStore.Read(ctx, from, limit)
+}
+
+func (f *flakyStore) SaveOffset(ctx context.Context, id string, offset Offset) error {
+	if f.saveFails.Add(-1) >= 0 {
+		return errors.New("transient save failure")
+	}
+	return f.MemoryStore.SaveOffset(ctx, id, offset)
+}
+
+func (f *flakyStore) LoadOffset(ctx context.Context, id string) (Offset, error) {
+	if f.loadFails.Add(-1) >= 0 {
+		return OffsetOldest, errors.New("load failure")
+	}
+	return f.MemoryStore.LoadOffset(ctx, id)
+}
+
+func TestFollowRetriesReadErrors(t *testing.T) {
+	store := &flakyStore{MemoryStore: NewMemoryStore()}
+	store.readFails.Store(2)
+	consumer := New(WithStore(store))
+
+	var reported atomic.Int32
+	consumer.SetPersistenceErrorHandler(func(event any, eventType reflect.Type, err error) {
+		reported.Add(1)
+	})
+
+	var count atomic.Int32
+	Subscribe(consumer, func(e followEvent) { count.Add(1) })
+
+	if _, err := store.MemoryStore.Append(context.Background(), &Event{
+		ID: NewEventID(), Type: "eventbus.followEvent", Data: json.RawMessage(`{"Value":1}`), Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stop := startFollower(t, consumer, FollowFrom(OffsetOldest), fastPoll)
+	defer stop()
+
+	waitFor(t, 5*time.Second, "delivery after read failures", func() bool { return count.Load() == 1 })
+	if reported.Load() == 0 {
+		t.Error("read failures must be reported")
+	}
+}
+
+func TestFollowReportsSaveOffsetErrors(t *testing.T) {
+	store := &flakyStore{MemoryStore: NewMemoryStore()}
+	store.saveFails.Store(1)
+	consumer := New(WithStore(store))
+
+	var reported atomic.Int32
+	consumer.SetPersistenceErrorHandler(func(event any, eventType reflect.Type, err error) {
+		reported.Add(1)
+	})
+	var count atomic.Int32
+	Subscribe(consumer, func(e followEvent) { count.Add(1) })
+
+	Publish(New(WithStore(store.MemoryStore)), followEvent{Value: 1})
+
+	stop := startFollower(t, consumer, FollowFrom(OffsetOldest), fastPoll, FollowWithSubscriptionID("s"))
+	defer stop()
+
+	waitFor(t, 5*time.Second, "delivery despite save failure", func() bool { return count.Load() == 1 })
+	waitFor(t, 5*time.Second, "save failure report", func() bool { return reported.Load() >= 1 })
+}
+
+func TestFollowLoadOffsetFailureIsFatal(t *testing.T) {
+	store := &flakyStore{MemoryStore: NewMemoryStore()}
+	store.loadFails.Store(1)
+	consumer := New(WithStore(store))
+	if err := consumer.Follow(context.Background(), FollowWithSubscriptionID("s")); err == nil {
+		t.Error("expected Follow to fail when the saved offset cannot be loaded")
+	}
+}
+
+// fixtureTailer implements EventStore + EventStoreTailer: Tail yields the
+// scripted events (optionally an error first), then blocks until ctx is done.
+type fixtureTailer struct {
+	events   []*StoredEvent
+	failures atomic.Int32
+}
+
+func (f *fixtureTailer) Append(ctx context.Context, event *Event) (Offset, error) {
+	return "", errors.New("read-only fixture")
+}
+
+func (f *fixtureTailer) Read(ctx context.Context, from Offset, limit int) ([]*StoredEvent, Offset, error) {
+	return nil, from, nil
+}
+
+func (f *fixtureTailer) Tail(ctx context.Context, from Offset) iter.Seq2[*StoredEvent, error] {
+	return func(yield func(*StoredEvent, error) bool) {
+		if f.failures.Add(-1) >= 0 {
+			yield(nil, errors.New("transient tail failure"))
+			return
+		}
+		for _, ev := range f.events {
+			if ev.Offset <= from && ev.Offset != "" {
+				continue // already consumed on a previous tail
+			}
+			if !yield(ev, nil) {
+				return
+			}
+		}
+		<-ctx.Done()
+	}
+}
+
+func TestFollowTailerPath(t *testing.T) {
+	store := &fixtureTailer{events: []*StoredEvent{
+		{Offset: "00000000000000000001", ID: NewEventID(), Type: "eventbus.followEvent", Data: json.RawMessage(`{"Value":1}`)},
+		{Offset: "00000000000000000002", ID: NewEventID(), Type: "eventbus.followEvent", Data: json.RawMessage(`{"Value":2}`)},
+	}}
+	store.failures.Store(1) // first tail fails; follower must report and re-tail
+
+	consumer := New(WithStore(store))
+	var reported atomic.Int32
+	consumer.SetPersistenceErrorHandler(func(event any, eventType reflect.Type, err error) {
+		reported.Add(1)
+	})
+
+	var got []int
+	var mu sync.Mutex
+	Subscribe(consumer, func(e followEvent) { mu.Lock(); got = append(got, e.Value); mu.Unlock() })
+
+	stop := startFollower(t, consumer, FollowFrom(OffsetOldest), fastPoll)
+	defer stop()
+
+	waitFor(t, 5*time.Second, "tailed delivery", func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(got) == 2
+	})
+	if reported.Load() == 0 {
+		t.Error("tail failure must be reported")
+	}
+}
+
+func TestFollowTailerEmptyOffsetEvent(t *testing.T) {
+	// An event with no offset (some external tail sources) must still deliver,
+	// just without an offset in the handler context.
+	store := &fixtureTailer{events: []*StoredEvent{
+		{Offset: "", ID: NewEventID(), Type: "eventbus.followEvent", Data: json.RawMessage(`{"Value":9}`)},
+	}}
+	consumer := New(WithStore(store))
+
+	var sawOffset atomic.Bool
+	var count atomic.Int32
+	SubscribeContext(consumer, func(ctx context.Context, e followEvent) {
+		_, ok := OffsetFromContext(ctx)
+		sawOffset.Store(ok)
+		count.Add(1)
+	})
+
+	stop := startFollower(t, consumer, FollowFrom(OffsetOldest), fastPoll)
+	defer stop()
+
+	waitFor(t, 5*time.Second, "offsetless delivery", func() bool { return count.Load() == 1 })
+	if sawOffset.Load() {
+		t.Error("an offsetless event must not fabricate an offset in context")
+	}
+}
+
+func TestRegisterFollowDecoderIdempotent(t *testing.T) {
+	bus := New()
+	Subscribe(bus, func(e followEvent) {})
+	Subscribe(bus, func(e followEvent) {})
+	bus.followMu.RLock()
+	defer bus.followMu.RUnlock()
+	if len(bus.followDecoders) != 1 {
+		t.Errorf("expected 1 decoder, got %d", len(bus.followDecoders))
+	}
+}
+
+// --- Cancellation branch coverage ---
+
+func TestFollowPreCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	poll := New(WithStore(NewMemoryStore()))
+	if err := poll.Follow(ctx, fastPoll); !errors.Is(err, context.Canceled) {
+		t.Errorf("poll path: got %v, want context.Canceled", err)
+	}
+
+	tail := New(WithStore(&fixtureTailer{}))
+	if err := tail.Follow(ctx, fastPoll); !errors.Is(err, context.Canceled) {
+		t.Errorf("tail path: got %v, want context.Canceled", err)
+	}
+}
+
+func TestFollowCancelDuringTailSleep(t *testing.T) {
+	// An empty store parks the poll loop in its at-the-tail sleep; cancelling
+	// there must end Follow promptly despite the huge interval.
+	bus := New(WithStore(NewMemoryStore()))
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- bus.Follow(ctx, FollowPollInterval(time.Hour)) }()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("got %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Follow did not return from the tail sleep")
+	}
+}
+
+func TestFollowCancelDuringErrorBackoff(t *testing.T) {
+	store := &flakyStore{MemoryStore: NewMemoryStore()}
+	store.readFails.Store(1 << 30) // never recovers
+	bus := New(WithStore(store))
+
+	var reported atomic.Int32
+	bus.SetPersistenceErrorHandler(func(event any, eventType reflect.Type, err error) {
+		reported.Add(1)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- bus.Follow(ctx, FollowPollInterval(time.Hour)) }()
+	waitFor(t, 5*time.Second, "read error report", func() bool { return reported.Load() >= 1 })
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("got %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Follow did not return from the error backoff")
+	}
+}
+
+func TestFollowCancelDuringTailBackoff(t *testing.T) {
+	store := &fixtureTailer{}
+	store.failures.Store(1 << 30) // every tail attempt fails
+	bus := New(WithStore(store))
+
+	var reported atomic.Int32
+	bus.SetPersistenceErrorHandler(func(event any, eventType reflect.Type, err error) {
+		reported.Add(1)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- bus.Follow(ctx, FollowPollInterval(time.Hour)) }()
+	waitFor(t, 5*time.Second, "tail error report", func() bool { return reported.Load() >= 1 })
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("got %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Follow did not return from the tail backoff")
+	}
+}
+
+// cancellingStore fails Read after cancelling the follower's context,
+// simulating a store call that failed *because* of shutdown: the follower
+// must return the cancellation, not report and retry.
+type cancellingStore struct {
+	inner  *MemoryStore
+	cancel context.CancelFunc
+}
+
+func (c *cancellingStore) Append(ctx context.Context, event *Event) (Offset, error) {
+	return c.inner.Append(ctx, event)
+}
+
+func (c *cancellingStore) Read(ctx context.Context, from Offset, limit int) ([]*StoredEvent, Offset, error) {
+	c.cancel()
+	return nil, from, errors.New("read aborted by shutdown")
+}
+
+func TestFollowReadErrorFromCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	store := &cancellingStore{inner: NewMemoryStore(), cancel: cancel}
+	bus := New(WithStore(store))
+
+	reportedBeforeCancel := false
+	bus.SetPersistenceErrorHandler(func(event any, eventType reflect.Type, err error) {
+		reportedBeforeCancel = true
+	})
+
+	if err := bus.Follow(ctx, fastPoll); !errors.Is(err, context.Canceled) {
+		t.Errorf("got %v, want context.Canceled", err)
+	}
+	if reportedBeforeCancel {
+		t.Error("a read failing due to shutdown must not be reported as a store error")
+	}
+}

--- a/persist.go
+++ b/persist.go
@@ -633,6 +633,7 @@ func SubscribeWithReplay[T any](
 	// Options were already applied by buildHandler above — registering the
 	// same handler instance keeps each option's effect applied exactly once.
 	bus.addHandler(eventType, h)
+	registerFollowDecoder[T](bus)
 
 	// Catch-up pass: an event persisted after the first replay finished but
 	// before the live subscription registered would otherwise be missed

--- a/stores/durablestream/store.go
+++ b/stores/durablestream/store.go
@@ -36,6 +36,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"iter"
 	"net/http"
 	"sync"
 	"time"
@@ -63,8 +64,9 @@ type Store struct {
 	writer *durablestream.StreamWriter
 }
 
-// Ensure Store implements the EventStore interface.
+// Ensure Store implements the EventStore and EventStoreTailer interfaces.
 var _ eventbus.EventStore = (*Store)(nil)
+var _ eventbus.EventStoreTailer = (*Store)(nil)
 
 // New creates a new Store connected to a durable-streams server.
 //
@@ -325,55 +327,9 @@ func (s *Store) Read(ctx context.Context, from eventbus.Offset, limit int) ([]*e
 			return nil, from, fmt.Errorf("durablestream: read: giving up after %d attempts: %w", s.cfg.retryAttempts, lastErr)
 		}
 
-		// Parse JSON array response (an empty body yields no events).
-		var rawEvents []json.RawMessage
-		if len(result.Data) > 0 {
-			if err := json.Unmarshal(result.Data, &rawEvents); err != nil {
-				return nil, from, fmt.Errorf("durablestream: unmarshal response: %w", err)
-			}
-		}
-
-		// Convert to StoredEvents
-		events := make([]*eventbus.StoredEvent, 0, len(rawEvents))
-		allEmbedded := true
-		lastRaw := len(rawEvents) - 1
-		for i, raw := range rawEvents {
-			// Try to parse as event with embedded offset first
-			var eventWithOffset storedEventWithOffset
-			if err := json.Unmarshal(raw, &eventWithOffset); err != nil {
-				s.handleDecodeError(i, raw, err)
-				continue
-			}
-
-			// Determine the event's resume offset. Every emitted offset is
-			// server-issued and safe to store: resuming from it may re-deliver
-			// earlier events (at-least-once) but never skips a later one.
-			var eventOffset eventbus.Offset
-			switch {
-			case eventWithOffset.Offset != "":
-				// Embedded per-event offset: exact resumption.
-				eventOffset = eventbus.Offset(eventWithOffset.Offset)
-			case i == lastRaw:
-				// The server's next-offset is exactly the resume point after
-				// the chunk's last event.
-				eventOffset = eventbus.Offset(result.NextOffset)
-				allEmbedded = false
-			default:
-				// Chunk-start: resuming re-reads this chunk from the start,
-				// re-delivering earlier events but never skipping later ones.
-				eventOffset = chunkStart
-				allEmbedded = false
-			}
-
-			events = append(events, &eventbus.StoredEvent{
-				Offset:    eventOffset,
-				ID:        eventWithOffset.ID,
-				Origin:    eventWithOffset.Origin,
-				Type:      eventWithOffset.Type,
-				Data:      eventWithOffset.Data,
-				Metadata:  eventWithOffset.Metadata,
-				Timestamp: parseTimestamp(eventWithOffset.Timestamp),
-			})
+		events, allEmbedded, err := s.decodeChunk(result, chunkStart)
+		if err != nil {
+			return nil, from, err
 		}
 
 		if len(events) == 0 {
@@ -400,6 +356,147 @@ func (s *Store) Read(ctx context.Context, from eventbus.Offset, limit int) ([]*e
 		}
 
 		return events, eventbus.Offset(result.NextOffset), nil
+	}
+}
+
+// decodeChunk converts one read result into StoredEvents, assigning each a
+// resume-safe offset (see Read's offset semantics). chunkStart is the offset
+// the chunk was read from; allEmbedded reports whether every event carried
+// its own embedded offset (exact resumption possible).
+func (s *Store) decodeChunk(result *durablestream.StreamData, chunkStart eventbus.Offset) (events []*eventbus.StoredEvent, allEmbedded bool, err error) {
+	// Parse JSON array response (an empty body yields no events).
+	var rawEvents []json.RawMessage
+	if len(result.Data) > 0 {
+		if err := json.Unmarshal(result.Data, &rawEvents); err != nil {
+			return nil, false, fmt.Errorf("durablestream: unmarshal response: %w", err)
+		}
+	}
+
+	// Convert to StoredEvents
+	events = make([]*eventbus.StoredEvent, 0, len(rawEvents))
+	allEmbedded = true
+	lastRaw := len(rawEvents) - 1
+	for i, raw := range rawEvents {
+		// Try to parse as event with embedded offset first
+		var eventWithOffset storedEventWithOffset
+		if err := json.Unmarshal(raw, &eventWithOffset); err != nil {
+			s.handleDecodeError(i, raw, err)
+			continue
+		}
+
+		// Determine the event's resume offset. Every emitted offset is
+		// server-issued and safe to store: resuming from it may re-deliver
+		// earlier events (at-least-once) but never skips a later one.
+		var eventOffset eventbus.Offset
+		switch {
+		case eventWithOffset.Offset != "":
+			// Embedded per-event offset: exact resumption.
+			eventOffset = eventbus.Offset(eventWithOffset.Offset)
+		case i == lastRaw:
+			// The server's next-offset is exactly the resume point after
+			// the chunk's last event.
+			eventOffset = eventbus.Offset(result.NextOffset)
+			allEmbedded = false
+		default:
+			// Chunk-start: resuming re-reads this chunk from the start,
+			// re-delivering earlier events but never skipping later ones.
+			eventOffset = chunkStart
+			allEmbedded = false
+		}
+
+		events = append(events, &eventbus.StoredEvent{
+			Offset:    eventOffset,
+			ID:        eventWithOffset.ID,
+			Origin:    eventWithOffset.Origin,
+			Type:      eventWithOffset.Type,
+			Data:      eventWithOffset.Data,
+			Metadata:  eventWithOffset.Metadata,
+			Timestamp: parseTimestamp(eventWithOffset.Timestamp),
+		})
+	}
+	return events, allEmbedded, nil
+}
+
+// Tail implements eventbus.EventStoreTailer over the durable-streams live
+// protocol: a persistent Reader catches up with plain reads, then switches to
+// long-poll (or SSE, per the client's ReadMode), so new events are pushed to
+// the follower within one round trip instead of discovered by polling.
+//
+// Offset semantics match Read: per-event offsets are resume-safe but may
+// re-deliver on restart (at-least-once); consumers deduplicate on ID.
+//
+// Retry policy: transient failures (network errors, HTTP 5xx, 429 — and
+// notably client-side timeouts of an idle long-poll) are retried forever
+// with capped exponential backoff, because an idle stream is
+// indistinguishable from a transiently failing one. Permanent protocol
+// errors (not found, gone, bad request) and undecodable chunks are yielded
+// and end the tail. The iterator ends silently when ctx is cancelled.
+func (s *Store) Tail(ctx context.Context, from eventbus.Offset) iter.Seq2[*eventbus.StoredEvent, error] {
+	return func(yield func(*eventbus.StoredEvent, error) bool) {
+		start := from
+		if from == eventbus.OffsetNewest {
+			tail, err := s.resolveTail(ctx)
+			if err != nil {
+				if ctx.Err() == nil {
+					yield(nil, err)
+				}
+				return
+			}
+			start = tail
+		}
+
+		toServerOffset := func(o eventbus.Offset) durablestream.Offset {
+			if o == eventbus.OffsetOldest {
+				return durablestream.ZeroOffset
+			}
+			return durablestream.Offset(o)
+		}
+
+		reader := s.client.Reader(s.path, toServerOffset(start))
+		chunkStart := start
+		retry := 0
+		for {
+			if ctx.Err() != nil {
+				return
+			}
+
+			result, err := reader.Read(ctx)
+			if err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				if !isRetryable(err) {
+					yield(nil, fmt.Errorf("durablestream: tail: %w", err))
+					return
+				}
+				// The reader may hold a stale connection or cursor; rebuild it
+				// at the last known chunk boundary and back off (capped — see
+				// maxBackoffShift — never giving up: idle long-polls time out
+				// client-side and look exactly like transient failures).
+				retry++
+				if backoff(ctx, s.cfg.retryBaseDelay, retry) != nil {
+					return
+				}
+				reader = s.client.Reader(s.path, toServerOffset(chunkStart))
+				continue
+			}
+			retry = 0
+
+			events, _, err := s.decodeChunk(result, chunkStart)
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			for _, event := range events {
+				if !yield(event, nil) {
+					return
+				}
+			}
+			chunkStart = eventbus.Offset(result.NextOffset)
+			// An empty result (long-poll window expired, or an empty chunk)
+			// needs no sleep: the next Read blocks server-side until data
+			// arrives or the window times out again.
+		}
 	}
 }
 

--- a/stores/durablestream/tail_test.go
+++ b/stores/durablestream/tail_test.go
@@ -1,0 +1,186 @@
+package durablestream_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	eventbus "github.com/jilio/ebu"
+	ds "github.com/jilio/ebu/stores/durablestream"
+)
+
+// TestTailCatchUpAndLive verifies Tail against a real protocol handler:
+// existing events are caught up, and an event appended while the tail is
+// live arrives without restarting the iterator.
+func TestTailCatchUpAndLive(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	store, err := ds.New(srv.URL+"/v1/stream", "tail-test")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	appendEvent := func(v int) {
+		t.Helper()
+		if _, err := store.Append(ctx, &eventbus.Event{
+			ID:   eventbus.NewEventID(),
+			Type: "tail.event",
+			Data: json.RawMessage(`{}`),
+		}); err != nil {
+			t.Fatalf("Append(%d) error = %v", v, err)
+		}
+	}
+
+	appendEvent(1)
+	appendEvent(2)
+
+	var mu sync.Mutex
+	var got []*eventbus.StoredEvent
+	tailDone := make(chan struct{})
+	go func() {
+		defer close(tailDone)
+		for event, err := range store.Tail(ctx, eventbus.OffsetOldest) {
+			if err != nil {
+				if ctx.Err() == nil {
+					t.Errorf("Tail yielded error: %v", err)
+				}
+				return
+			}
+			mu.Lock()
+			got = append(got, event)
+			mu.Unlock()
+		}
+	}()
+
+	waitCount := func(n int, what string) {
+		t.Helper()
+		deadline := time.Now().Add(10 * time.Second)
+		for time.Now().Before(deadline) {
+			mu.Lock()
+			count := len(got)
+			mu.Unlock()
+			if count >= n {
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		t.Fatalf("timed out waiting for %s", what)
+	}
+
+	waitCount(2, "catch-up events")
+
+	appendEvent(3) // arrives via the live long-poll
+	waitCount(3, "live event")
+
+	mu.Lock()
+	for i, ev := range got {
+		if ev.Type != "tail.event" {
+			t.Errorf("event %d: unexpected type %q", i, ev.Type)
+		}
+		if ev.ID == "" {
+			t.Errorf("event %d: envelope ID lost in tail path", i)
+		}
+	}
+	mu.Unlock()
+
+	cancel()
+	select {
+	case <-tailDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Tail did not end after context cancellation")
+	}
+}
+
+// TestTailFromNewestSkipsHistory verifies OffsetNewest resolution: only
+// events appended after the tail starts are yielded.
+func TestTailFromNewestSkipsHistory(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	store, err := ds.New(srv.URL+"/v1/stream", "tail-newest-test")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if _, err := store.Append(ctx, &eventbus.Event{Type: "old", Data: json.RawMessage(`{}`)}); err != nil {
+		t.Fatal(err)
+	}
+
+	var mu sync.Mutex
+	var got []string
+	go func() {
+		for event, err := range store.Tail(ctx, eventbus.OffsetNewest) {
+			if err != nil {
+				return
+			}
+			mu.Lock()
+			got = append(got, event.Type)
+			mu.Unlock()
+		}
+	}()
+
+	// Let the tail resolve the tip and enter live mode, then append.
+	time.Sleep(100 * time.Millisecond)
+	if _, err := store.Append(ctx, &eventbus.Event{Type: "new", Data: json.RawMessage(`{}`)}); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		done := len(got) >= 1
+		mu.Unlock()
+		if done {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) != 1 || got[0] != "new" {
+		t.Errorf("expected only the post-tail event, got %v", got)
+	}
+}
+
+// TestTailMissingStreamYieldsError verifies permanent errors end the tail.
+func TestTailMissingStreamYieldsError(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	store, err := ds.New(srv.URL+"/v1/stream", "tail-error-test")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	// Point at a stream that was never created by deleting it first.
+	if err := store.Client().Delete(context.Background(), "tail-error-test"); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var tailErr error
+	for _, err := range store.Tail(ctx, eventbus.OffsetOldest) {
+		if err != nil {
+			tailErr = err
+			break
+		}
+	}
+	if tailErr == nil {
+		t.Fatal("expected the tail to yield an error for a missing stream")
+	}
+	if errors.Is(tailErr, context.DeadlineExceeded) {
+		t.Fatalf("tail should fail fast on a permanent error, got %v", tailErr)
+	}
+}


### PR DESCRIPTION
Stacked on #51 (event envelope is the foundation). Implements scaling beyond a single process as laid out in the review: **every process appends to a shared log by publishing, and receives by following.**

## The primitive: `bus.Follow(ctx, opts...)`

A blocking loop that tails the bus's `EventStore` and dispatches each new event to the local handlers subscribed to its type — with full option semantics (filters, `Once`, `Async`, `Sequential`, panic recovery) and working context values (`OffsetFromContext`, `EventIDFromContext`, `MetadataFromContext`). Registered upcasts apply before decoding, as in `Replay`.

- **Echo suppression**: events this bus itself published are skipped by envelope `Origin` (they were already delivered at publish time). Override with `FollowIncludeOwn()`.
- **Dedup**: at-least-once duplicates (retried appends, chunk re-reads, post-crash replays) are dropped by event ID within `FollowDedupWindow` (default 1024).
- **Durability**: `FollowWithSubscriptionID("name")` resumes from the saved offset after a restart (first run consumes the full log, like `SubscribeWithReplay`).
- **Resilience**: read/tail errors are reported to the `PersistenceErrorHandler` and retried; poison events are reported (with the `*StoredEvent` for recovery) and skipped. The follower only exits on context cancellation.
- Subscribe entry points now register a per-type decoder (type name → Go type), which is what lets the follower decode stored JSON back into typed events.

## `WithLogDelivery`: the log is the source of truth

`Publish` appends and returns; **all** delivery — including in the publishing process — comes from the follower. Every process observes the same events in the same order, and an event that failed to persist is never observed anywhere (this resolves the replay-divergence concern from the review by construction). Requires `WithStore`; `New` panics otherwise. Verified by a test that interleaves two publishers and asserts both buses consume identical sequences.

## `EventStoreTailer` + durablestream `Tail`

New optional store capability for push-based tailing; `Follow` uses it when present and falls back to polling `Read` (`FollowPollInterval`, default 200ms). The durablestream store implements it over the protocol's **live long-poll/SSE modes** via a persistent `Reader`, so followers get new events within one round trip. Transient failures retry forever with capped backoff — deliberately, because a client-side timeout of an idle long-poll is indistinguishable from a transient failure; permanent protocol errors end the tail. Tested against the real protocol handler, including an event appended mid-tail arriving via live long-poll.

## Docs

`docs/DISTRIBUTED.md` covers the architecture, both delivery modes, at-least-once guidance, failure behavior, and the explicit roadmap left for follow-ups: **consumer leases/partitioning** (competing consumers on one subscription ID are not coordinated yet) and a **Postgres store** (table + LISTEN/NOTIFY tail — the two interfaces it needs are now in place).

## Verification
- `go test -race ./...` green in all five modules
- Core coverage **100.0%** (per-function verified), including all follower cancellation/backoff branches
- Cross-bus tests: delivery, ordering, echo suppression, durable resume, dedup, poison/unknown-type skips, upcasts, tailer path

## CI note
Same sub-module caveat as #51: `stores/*` legs run `GOWORK=off` against released core and stay red until the next core tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)